### PR TITLE
Supabase streak data sync

### DIFF
--- a/frontend/constants/supabase.ts
+++ b/frontend/constants/supabase.ts
@@ -127,6 +127,8 @@ export const SCHEMA = {
     user_id: 'uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE',
     current_streak: 'integer NOT NULL DEFAULT 0',
     max_streak: 'integer NOT NULL DEFAULT 0',
+    last_entry_date: 'date',
+    last_access_time: 'timestamptz',
     created_at: 'timestamptz DEFAULT now()',
     updated_at: 'timestamptz DEFAULT now()',
   }

--- a/frontend/supabase/migrations/20260111000000_streaks.sql
+++ b/frontend/supabase/migrations/20260111000000_streaks.sql
@@ -7,6 +7,8 @@
       - `user_id` (uuid, references auth.users)
       - `current_streak` (integer)
       - `max_streak` (integer)
+      - `last_entry_date` (date, nullable)
+      - `last_access_time` (timestamptz, nullable)
       - `created_at` (timestamp)
       - `updated_at` (timestamp)
 
@@ -21,6 +23,8 @@ CREATE TABLE IF NOT EXISTS user_streaks (
   user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
   current_streak integer NOT NULL DEFAULT 0,
   max_streak integer NOT NULL DEFAULT 0,
+  last_entry_date date,
+  last_access_time timestamptz,
   created_at timestamptz NOT NULL DEFAULT now(),
   updated_at timestamptz NOT NULL DEFAULT now()
 );
@@ -58,7 +62,7 @@ CREATE POLICY "Users can update own streak"
   ON user_streaks
   FOR UPDATE
   TO authenticated
-  USING (auth.uid() = user_id);
+  USING (auth.uid() = user_id)
   WITH CHECK (auth.uid() = user_id);
 
 CREATE POLICY "Users can delete own streak"

--- a/frontend/types/database.ts
+++ b/frontend/types/database.ts
@@ -323,6 +323,8 @@ export interface Database {
           user_id: string
           current_streak: number
           max_streak: number
+          last_entry_date: string | null
+          last_access_time: string | null
           created_at: string
           updated_at: string
         }
@@ -331,6 +333,8 @@ export interface Database {
           user_id: string
           current_streak?: number
           max_streak?: number
+          last_entry_date?: string | null
+          last_access_time?: string | null
           created_at?: string
           updated_at?: string
         }
@@ -339,6 +343,8 @@ export interface Database {
           user_id?: string
           current_streak?: number
           max_streak?: number
+          last_entry_date?: string | null
+          last_access_time?: string | null
           created_at?: string
           updated_at?: string
         }


### PR DESCRIPTION
Sync streak data to Supabase to enable cross-device synchronization and persistence.

---
Linear Issue: [DEF-81](https://linear.app/fortunethedev/issue/DEF-81/sync-streak-data-to-supabase)

<a href="https://cursor.com/background-agent?bcId=bc-cef0d448-c81d-442b-9f57-f2eba134c25c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cef0d448-c81d-442b-9f57-f2eba134c25c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables cross-device persistence of streak stats.
> 
> - New `user_streaks` table (migration) with RLS policies, unique index on `user_id`, and `updated_at` trigger
> - `StreakService` now falls back to Supabase on load and upserts `current_streak`/`max_streak` on save; local storage kept as cache
> - Supabase constants/schema updated to include `USER_STREAKS`; TypeScript `Database` types extended for `user_streaks`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3e96f91cc2fa8a1720e289bf629068c50785cee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streaks now sync across devices: current and max streaks plus last entry/access times are persisted remotely.
  * Sync is best-effort and non-blocking—local streaks continue to work if remote sync is unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->