### PR TITLE
DEF-112: Use SVG default avatars for review/invite and render invite image with expo-image

### DIFF
--- a/frontend/app/capture/details.tsx
+++ b/frontend/app/capture/details.tsx
@@ -89,7 +89,7 @@ export default function DetailsScreen() {
         id,
         name: friendProfile?.full_name || 'Unknown User',
         username: friendProfile?.username ?? "",
-        avatar: friendProfile?.avatar_url || getDefaultAvatarUrl(friendProfile?.full_name ?? ""),
+        avatar: friendProfile?.avatar_url || getDefaultAvatarUrl(friendProfile?.full_name ?? "", 'svg'),
       };
     })
     .filter((friend): friend is Friend => friend !== null);

--- a/frontend/app/invite/[id].tsx
+++ b/frontend/app/invite/[id].tsx
@@ -1,10 +1,11 @@
-import React, { useEffect } from 'react';
-import { View, Text, TouchableOpacity, StyleSheet, SafeAreaView, Image, Alert, ActivityIndicator } from 'react-native';
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet, SafeAreaView, Alert, ActivityIndicator } from 'react-native';
 import { router, useLocalSearchParams } from 'expo-router';
 import Animated, { FadeInDown, FadeInUp } from 'react-native-reanimated';
 import { Check, X, Users } from 'lucide-react-native';
 import { useInviteAcceptance } from '@/hooks/use-invite-acceptance';
 import { useAuthContext } from '@/providers/auth-provider';
+import { Image } from 'expo-image';
 
 export default function AcceptInviteScreen() {
   const { id } = useLocalSearchParams();

--- a/frontend/hooks/use-invite-acceptance.ts
+++ b/frontend/hooks/use-invite-acceptance.ts
@@ -27,7 +27,7 @@ interface UseInviteAcceptanceResult {
   error: string | null;
   isProcessing: boolean;
   acceptInvite: (inviteeId: string, userId: string) => Promise<InviteResult>;
-  declineInvite: (inviteId: string) => Promise<InviteResult>;
+  declineInvite: (_inviteId: string) => Promise<InviteResult>;
 }
 
 export function useInviteAcceptance(inviteCode?: string): UseInviteAcceptanceResult {
@@ -111,7 +111,7 @@ export function useInviteAcceptance(inviteCode?: string): UseInviteAcceptanceRes
         id: inviterProfile.id,
         inviterName: inviterName,
         inviterEmail: inviterProfile?.email || '',
-        inviterAvatar: inviterProfile?.avatar_url || getDefaultAvatarUrl(inviterName),
+        inviterAvatar: inviterProfile?.avatar_url || getDefaultAvatarUrl(inviterName, 'svg'),
         message: "",
         isUsed: false,
       };
@@ -160,7 +160,7 @@ export function useInviteAcceptance(inviteCode?: string): UseInviteAcceptanceRes
     }
   }, [acceptInviteMutation]);
 
-  const declineInvite = useCallback(async (inviteId: string): Promise<InviteResult> => {
+  const declineInvite = useCallback(async (_inviteId: string): Promise<InviteResult> => {
     setIsProcessing(true);
 
     try {

--- a/frontend/lib/utils.ts
+++ b/frontend/lib/utils.ts
@@ -3,8 +3,8 @@ import { MediaType } from "@/types/media"
 import { TZDate } from "@date-fns/tz";
 import { getRandomBytesAsync } from 'expo-crypto';
 
-export const getDefaultAvatarUrl = (fullName: string) => {
-    return `https://api.dicebear.com/9.x/adventurer-neutral/png?seed=${fullName}`
+export const getDefaultAvatarUrl = (fullName: string, format: 'png' | 'svg' = 'png') => {
+    return `https://api.dicebear.com/9.x/adventurer/${format}?seed=${fullName}`
 }
 
 export const getFileExtension = (type: MediaType) => {


### PR DESCRIPTION
### Motivation
- Ensure the profile image shown at review/invite flows uses SVG avatars for crisper visuals and smaller payloads.
- Add a `format` option to the default avatar helper so callers can request `svg` or keep the existing `png` default.
- Standardize image rendering on the invite screen to use the `expo-image` package used across the app.

### Description
- Updated `getDefaultAvatarUrl` signature to `getDefaultAvatarUrl(fullName: string, format: 'png' | 'svg' = 'png')` and changed the DiceBear URL to `https://api.dicebear.com/9.x/adventurer/{format}?seed={}`.
- Switched review-stage friend avatar fallback in `frontend/app/capture/details.tsx` to request SVG defaults via `getDefaultAvatarUrl(..., 'svg')`.
- Switched inviter avatar fallback in `frontend/hooks/use-invite-acceptance.ts` to request SVG by default when profile avatar is missing.
- Updated `frontend/app/invite/[id].tsx` to import and render the inviter profile image with `Image` from `expo-image` and removed the unused `useEffect` import; renamed an unused parameter to `_inviteId` to reduce dead/unreferenced code.

### Testing
- Ran `npm run lint` which failed in this environment due to ESLint v9 expecting an `eslint.config.js` while the project uses a legacy config, so linting could not be validated here.
- Ran `npx tsc --noEmit` which failed due to pre-existing TypeScript errors in the codebase unrelated to these changes, so type-checking could not be fully validated here.
- Started the Expo web server and attempted an automated Playwright screenshot to visually validate the invite page, but the browser run timed out while connecting to the local dev server.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e8efaa30c832aa9ab9177470f6dc9)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated avatar rendering format for enhanced visual consistency across the application.
  * Optimized image loading performance in invitation screens with improved image component handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->