### PR TITLE
Update mobile permission purpose strings for camera, microphone, contacts, and location

### DIFF
--- a/frontend/app.json
+++ b/frontend/app.json
@@ -97,8 +97,8 @@
       [
         "expo-camera",
         {
-          "cameraPermission": "Allow Keepsafe to access your camera",
-          "microphonePermission": "Allow Keepsafe to access your microphone",
+          "cameraPermission": "Allow Keepsafe access your camera for photo and video entries",
+          "microphonePermission": "Allow Keepsafe access your microphone for audio entries",
           "recordAudioAndroid": true
         }
       ],
@@ -111,7 +111,7 @@
       [
         "expo-contacts",
         {
-          "contactsPermission": "Allow Keepsafe to access your contacts."
+          "contactsPermission": "Allow Keepsafe to access your contacts to help you find friends"
         }
       ],
       [
@@ -124,7 +124,7 @@
       [
         "expo-audio",
         {
-          "microphonePermission": "Allow Keepsafe to access your microphone."
+          "microphonePermission": "Allow Keepsafe access your microphone for audio entries"
         }
       ],
       "expo-background-task",
@@ -132,8 +132,8 @@
       [
         "expo-location",
         {
-          "locationAlwaysPermission": "Allow Keepsafe to use your location at all times.",
-          "locationWhenInUsePermission": "Allow Keepsafe to use your location while you are using the app.",
+          "locationAlwaysPermission": "Allow Keepsafe to access your location to let friends know your location",
+          "locationWhenInUsePermission": "Allow Keepsafe to access your location to let friends know your location",
           "isIosBackgroundLocationEnabled": false
         }
       ]


### PR DESCRIPTION
### Motivation
- iOS requires descriptive purpose strings explaining why an app requests camera, microphone, contacts, and location access. 
- Provide explicit examples showing how each device capability is used (photo/video entries, audio entries, finding friends, sharing location). 
- Apply these clearer strings in the Expo config so they are available for iOS usage descriptions and Android prompts where supported.

### Description
- Updated `frontend/app.json` to change `expo-camera` plugin strings to `"cameraPermission": "Allow Keepsafe access your camera for photo and video entries"` and `"microphonePermission": "Allow Keepsafe access your microphone for audio entries"`.
- Updated `expo-audio` plugin `microphonePermission` to `"Allow Keepsafe access your microphone for audio entries"` in `frontend/app.json`.
- Updated `expo-contacts` plugin `contactsPermission` to `"Allow Keepsafe to access your contacts to help you find friends"` in `frontend/app.json`.
- Updated `expo-location` plugin `locationAlwaysPermission` and `locationWhenInUsePermission` to `"Allow Keepsafe to access your location to let friends know your location"` in `frontend/app.json`.

### Testing
- Verified `frontend/app.json` is valid JSON by running `python -m json.tool frontend/app.json >/dev/null`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7a58fe538832aaedd88459bcb59a5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced permission request descriptions to provide clearer explanations to users when granting access to camera, microphone, audio, contacts, and location features. Permission messages now explicitly detail the purpose for which each permission is needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->