### PR TITLE
Add EULA link on signup and strengthen EULA content rules

### DIFF
--- a/frontend/app/onboarding/auth.tsx
+++ b/frontend/app/onboarding/auth.tsx
@@ -345,7 +345,14 @@ export default function AuthScreen() {
                 >
                   Terms of Service
                 </Text>
-                {' '}and{' '}
+                {', '}
+                <Text
+                  style={styles.termsLink}
+                  onPress={() => router.push('/settings/legal?doc=eula')}
+                >
+                  EULA
+                </Text>
+                {' and '}
                 <Text
                   style={styles.termsLink}
                   onPress={() => router.push('/settings/legal?doc=privacy')}

--- a/frontend/app/settings/legal.tsx
+++ b/frontend/app/settings/legal.tsx
@@ -114,22 +114,27 @@ export default function LegalScreen() {
               Keepsafe may provide updates, patches, or modifications to the application. You agree to install such updates to continue using the service. We reserve the right to modify or discontinue features at any time.
             </Text>
 
-            <Text style={styles.sectionTitle}>5. Termination</Text>
+            <Text style={styles.sectionTitle}>5. Content and Conduct Requirements</Text>
+            <Text style={styles.sectionText}>
+              You must not post, upload, share, or otherwise distribute harmful, toxic, discriminatory, or sexual content on Keepsafe. If you fail to comply with this requirement, we may take enforcement action, including temporary account suspension or permanent account bans.
+            </Text>
+
+            <Text style={styles.sectionTitle}>6. Termination</Text>
             <Text style={styles.sectionText}>
               This license is effective until terminated. Your rights under this license will terminate automatically without notice if you fail to comply with any term of this Agreement. Upon termination, you must cease all use of the application and delete all copies.
             </Text>
 
-            <Text style={styles.sectionTitle}>6. Disclaimer of Warranties</Text>
+            <Text style={styles.sectionTitle}>7. Disclaimer of Warranties</Text>
             <Text style={styles.sectionText}>
               THE APPLICATION IS PROVIDED "AS IS" AND "AS AVAILABLE" WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT.
             </Text>
 
-            <Text style={styles.sectionTitle}>7. Limitation of Liability</Text>
+            <Text style={styles.sectionTitle}>8. Limitation of Liability</Text>
             <Text style={styles.sectionText}>
               TO THE MAXIMUM EXTENT PERMITTED BY LAW, KEEPSAFE SHALL NOT BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, OR ANY LOSS OF PROFITS OR REVENUES, WHETHER INCURRED DIRECTLY OR INDIRECTLY.
             </Text>
 
-            <Text style={styles.sectionTitle}>8. Governing Law</Text>
+            <Text style={styles.sectionTitle}>9. Governing Law</Text>
             <Text style={styles.sectionText}>
               This Agreement shall be governed by and construed in accordance with the laws of the jurisdiction in which Keepsafe operates, without regard to its conflict of law provisions.
             </Text>


### PR DESCRIPTION
### Motivation
- Make the End User License Agreement (EULA) discoverable during signup alongside the Terms of Service and Privacy Policy so users can review it before creating an account.
- Clarify acceptable content and enforcement in the EULA to explicitly prohibit harmful, toxic, discriminatory, or sexual content and to state consequences for violations.
- Preserve document ordering by renumbering subsequent sections after adding the new conduct clause.

### Description
- Inserted an `EULA` link into the signup legal acknowledgement text in `frontend/app/onboarding/auth.tsx` that routes to `/settings/legal?doc=eula`.
- Added a new "Content and Conduct Requirements" section to the EULA in `frontend/app/settings/legal.tsx` that forbids harmful, toxic, discriminatory, or sexual content and describes enforcement (temporary suspension or permanent bans).
- Renumbered the following EULA sections to maintain correct sequencing and adjusted small punctuation/spacing around the updated links.

### Testing
- Ran `npm --prefix frontend run lint`, which failed due to the repository using a legacy ESLint config while ESLint v9 expects a flat `eslint.config.*` file.
- Launched the web app with `npm --prefix frontend run web` and the Expo web server started successfully, but automated UI capture via Playwright timed out and no screenshot artifact was produced.
- No unit tests were executed as part of this change; no new automated tests were added.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7b17165cc832a99ebb7308160bf9a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added EULA link to the signup flow, positioned between Terms of Service and Privacy Policy.

* **Documentation**
  * Added "Content and Conduct Requirements" section to legal documentation outlining content policies and enforcement actions.
  * Reorganized and renumbered existing legal document sections for improved structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->