### PR TITLE
Add entry report UI and vault action popover; refactor headers and vault interactions

### DIFF
--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -84,6 +84,13 @@ export default function RootLayout() {
                       <Stack.Screen name="friends" />
                       <Stack.Screen name="dreamscape" />
                       <Stack.Screen name="search" />
+                      <Stack.Screen
+                        name="report-entry"
+                        options={{
+                          animationDuration: 350,
+                          animation: "fade_from_bottom"
+                        }}
+                      />
                       <Stack.Screen name="capture/details" />
                       <Stack.Screen name="+not-found" />
                     </Stack>

--- a/frontend/app/report-entry.tsx
+++ b/frontend/app/report-entry.tsx
@@ -1,0 +1,150 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { View, Text, StyleSheet, Pressable, TouchableOpacity, Alert } from 'react-native';
+import { router, useLocalSearchParams } from 'expo-router';
+import { scale, verticalScale } from 'react-native-size-matters';
+import { Colors } from '@/lib/constants';
+import { useAuthContext } from '@/providers/auth-provider';
+import { useMutation } from '@tanstack/react-query';
+import { deviceStorage } from '@/services/device-storage';
+import { useToast } from '@/hooks/use-toast';
+import PageHeader from '@/components/page-header';
+
+const REPORT_REASONS = [
+  'Harassment or bullying',
+  'Hate speech',
+  'Violence or threats',
+  'Sexual content',
+  'False information',
+  'Spam or scam',
+];
+
+export default function ReportEntryScreen() {
+  const { entryId } = useLocalSearchParams<{ entryId?: string }>();
+  const { user } = useAuthContext();
+  const { toast } = useToast();
+  const [selectedReason, setSelectedReason] = useState<string>('');
+
+  const safeEntryId = useMemo(() => {
+    if (!entryId || typeof entryId !== 'string') return '';
+    return entryId;
+  }, [entryId]);
+
+  const reportMutation = useMutation({
+    mutationFn: async () => {
+      if (!user?.id || !safeEntryId) {
+        throw new Error('Missing entry data for this report.');
+      }
+
+      await deviceStorage.removeEntry(user.id, safeEntryId);
+    },
+    onSuccess: () => {
+      toast('Entry reported. It has been removed from this device.');
+      router.replace('/vault');
+    },
+    onError: (error: Error) => {
+      toast(error.message || 'Unable to report this entry.', 'error');
+    }
+  });
+
+  useEffect(() => {
+    if (safeEntryId) return;
+    router.replace('/vault');
+  }, [safeEntryId]);
+
+  if (!safeEntryId) return null;
+
+  const handleConfirm = () => {
+    if (!selectedReason) {
+      Alert.alert('Reason required', 'Please pick a reason before submitting your report.');
+      return;
+    }
+
+    reportMutation.mutate();
+  };
+
+  return (
+    <View style={styles.container}>
+      <PageHeader title="Report Entry" backButtonPlacement="left" />
+      <Text style={styles.subtitle}>Why are you reporting this diary entry?</Text>
+
+      <View style={styles.reasonsContainer}>
+        {REPORT_REASONS.map(reason => {
+          const isSelected = selectedReason === reason;
+          return (
+            <Pressable
+              key={reason}
+              style={[styles.reasonItem, isSelected && styles.reasonItemSelected]}
+              onPress={() => setSelectedReason(reason)}
+            >
+              <Text style={[styles.reasonText, isSelected && styles.reasonTextSelected]}>{reason}</Text>
+            </Pressable>
+          );
+        })}
+      </View>
+
+      <TouchableOpacity
+        style={[styles.confirmButton, reportMutation.isPending && styles.confirmButtonDisabled]}
+        disabled={reportMutation.isPending}
+        onPress={handleConfirm}
+      >
+        <Text style={styles.confirmButtonText}>{reportMutation.isPending ? 'Submitting...' : 'Confirm Report'}</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#F0F9FF',
+    paddingHorizontal: scale(20),
+    paddingTop: verticalScale(20),
+    paddingBottom: verticalScale(30),
+  },
+  subtitle: {
+    marginTop: verticalScale(10),
+    marginBottom: verticalScale(24),
+    fontSize: scale(15),
+    color: '#475569',
+    fontFamily: 'Jost-Regular',
+  },
+  reasonsContainer: {
+    gap: verticalScale(10),
+    flex: 1,
+  },
+  reasonItem: {
+    borderWidth: 1,
+    borderColor: Colors.border,
+    backgroundColor: Colors.white,
+    borderRadius: 12,
+    paddingVertical: verticalScale(14),
+    paddingHorizontal: scale(14),
+  },
+  reasonItemSelected: {
+    borderColor: '#DC2626',
+    backgroundColor: '#FEE2E2',
+  },
+  reasonText: {
+    fontSize: scale(15),
+    color: Colors.text,
+    fontFamily: 'Jost-Regular',
+  },
+  reasonTextSelected: {
+    color: '#991B1B',
+    fontFamily: 'Jost-SemiBold',
+  },
+  confirmButton: {
+    backgroundColor: '#DC2626',
+    borderRadius: 12,
+    paddingVertical: verticalScale(16),
+    alignItems: 'center',
+  },
+  confirmButtonDisabled: {
+    opacity: 0.7,
+  },
+  confirmButtonText: {
+    color: Colors.white,
+    fontSize: scale(16),
+    fontFamily: 'Jost-SemiBold',
+  },
+});

--- a/frontend/app/vault.tsx
+++ b/frontend/app/vault.tsx
@@ -155,7 +155,6 @@ export default function VaultScreen() {
   const handleReportEntry = () => {
     if (!actionEntry?.id) {
       setActionEntry(null);
-      router.replace('/vault');
       return;
     }
 

--- a/frontend/app/vault.tsx
+++ b/frontend/app/vault.tsx
@@ -1,10 +1,7 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
-import { View, Text, TouchableOpacity, StyleSheet, SafeAreaView, ActivityIndicator, Dimensions, Pressable } from 'react-native';
+import { View, Text, TouchableOpacity, StyleSheet, ActivityIndicator, Pressable, Alert } from 'react-native';
 import { router } from 'expo-router';
-import Animated, {
-  SlideInUp,
-  SlideInDown
-} from 'react-native-reanimated';
+import Animated from 'react-native-reanimated';
 import { useUserEntries } from '@/hooks/use-user-entries';
 import { usePopupParams } from '@/hooks/use-popup-params';
 import EntryReactionsPopup from '@/components/entry-reactions-popup';
@@ -16,21 +13,23 @@ import { FlashList, FlashListRef } from '@shopify/flash-list';
 import { DateContainer } from '@/components/date-container';
 import AudioPreviewPopover from '@/components/capture/music/audio-preview-popover';
 import { MusicTag } from '@/types/capture';
-import { useResponsive, useTabletLayout } from '@/hooks/use-responsive';
+import { useResponsive } from '@/hooks/use-responsive';
 import { ChevronLeft, Sparkles } from 'lucide-react-native';
 import { Colors } from '@/lib/constants';
 import NewEntriesIndicator from '@/components/new-entries-indicator';
-import { useTimezone } from '@/hooks/use-timezone';
+import { useToast } from '@/hooks/use-toast';
+import { EntryWithProfile } from '@/types/entries';
+import * as FileSystem from 'expo-file-system/legacy';
+import * as Sharing from 'expo-sharing';
+import { useMutation } from '@tanstack/react-query';
+import VaultEntryActionPopover from '@/components/vault/vault-entry-action-popover';
 
-const { height, width } = Dimensions.get('window');
-
-// Animation duration from AudioPreviewPopover (300ms) + buffer for cleanup
 const MUSIC_PLAYER_ANIMATION_DURATION = 300;
 const MUSIC_PLAYER_CLEANUP_DELAY = MUSIC_PLAYER_ANIMATION_DURATION + 50;
 
 export default function VaultScreen() {
   const responsive = useResponsive();
-  const tabletLayout = useTabletLayout();
+  const { toast } = useToast();
   const {
     entries,
     entriesByDate,
@@ -42,85 +41,51 @@ export default function VaultScreen() {
     unseenEntryIds,
     markEntriesAsSeen,
     loadMore,
-    hasMore
   } = useUserEntries();
-  const { selectedEntryId, popupType, isPopupVisible, showReactions, showComments, hidePopup } = usePopupParams();
-  const { convertToLocalTimezone } = useTimezone();
+  const { selectedEntryId, popupType, isPopupVisible, hidePopup } = usePopupParams();
 
-  const [isHeaderVisible, setIsHeaderVisible] = useState(false);
   const [selectedMusic, setSelectedMusic] = useState<MusicTag | null>(null);
   const [isMusicPlayerVisible, setIsMusicPlayerVisible] = useState(false);
+  const [actionEntry, setActionEntry] = useState<EntryWithProfile | null>(null);
 
-  const prevOffset = useRef(0);
-  const musicPlayerCleanupTimeoutRef = useRef<number | null>(null);
+  const musicPlayerCleanupTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const flashListRef = useRef<FlashListRef<string>>(null);
 
-  const handleScroll = (event: any) => {
-    if (!event?.nativeEvent?.contentOffset) return;
-
-    const currentOffset = event.nativeEvent.contentOffset.y;
-
-    if (currentOffset > prevOffset.current && isHeaderVisible) {
-      //Scrolling downwards
-      setIsHeaderVisible(false);
-    } else if (currentOffset < prevOffset.current && !isHeaderVisible) {
-      //Scrolling upwards
-      setIsHeaderVisible(true);
-    }
-
-    prevOffset.current = currentOffset;
-  };
-
-
-
-  const handleEntryReactions = (entryId: string) => {
-    showReactions(entryId);
-  };
-
-  const handleEntryComments = (entryId: string) => {
-    showComments(entryId);
-  };
-
   const handleMusicPress = (music: MusicTag) => {
-    // Clear any existing cleanup timeout when reopening
     if (musicPlayerCleanupTimeoutRef.current) {
       clearTimeout(musicPlayerCleanupTimeoutRef.current);
       musicPlayerCleanupTimeoutRef.current = null;
     }
+
     setSelectedMusic(music);
     setIsMusicPlayerVisible(true);
   };
 
   const closeMusicPlayer = () => {
     setIsMusicPlayerVisible(false);
-    // Clear any existing timeout before setting a new one
     if (musicPlayerCleanupTimeoutRef.current) {
       clearTimeout(musicPlayerCleanupTimeoutRef.current);
     }
-    // Delay clearing the music to allow exit animation to complete
+
     musicPlayerCleanupTimeoutRef.current = setTimeout(() => {
       setSelectedMusic(null);
       musicPlayerCleanupTimeoutRef.current = null;
     }, MUSIC_PLAYER_CLEANUP_DELAY);
   };
 
-  // Cleanup timeout on unmount
   useEffect(() => {
     return () => {
-      if (musicPlayerCleanupTimeoutRef.current) {
-        clearTimeout(musicPlayerCleanupTimeoutRef.current);
-        musicPlayerCleanupTimeoutRef.current = null;
-      }
+      if (!musicPlayerCleanupTimeoutRef.current) return;
+      clearTimeout(musicPlayerCleanupTimeoutRef.current);
+      musicPlayerCleanupTimeoutRef.current = null;
     };
   }, []);
 
-  // Viewability config for tracking when entries appear in viewport
   const viewabilityConfig = useRef({
-    itemVisiblePercentThreshold: 50, // 50% visible
-    minimumViewTime: 500, // 500ms
+    itemVisiblePercentThreshold: 50,
+    minimumViewTime: 500,
   }).current;
 
-  // Handler for when viewable items change
   const onViewableItemsChanged = useCallback(({ viewableItems }: { viewableItems: any[] }) => {
     const visibleEntryIds: string[] = [];
 
@@ -128,193 +93,234 @@ export default function VaultScreen() {
       const dateKey = item.item;
       const dateEntries = entriesByDate?.[dateKey] || [];
       dateEntries.forEach((entry: any) => {
-        if (unseenEntryIds.has(entry.id)) {
-          visibleEntryIds.push(entry.id);
-        }
+        if (!unseenEntryIds.has(entry.id)) return;
+        visibleEntryIds.push(entry.id);
       });
     });
 
-    if (visibleEntryIds.length > 0) {
-      markEntriesAsSeen(visibleEntryIds);
-    }
+    if (!visibleEntryIds.length) return;
+    markEntriesAsSeen(visibleEntryIds);
   }, [entriesByDate, unseenEntryIds, markEntriesAsSeen]);
 
-  // Scroll to top handler
   const scrollToTop = () => {
     flashListRef.current?.scrollToOffset({ offset: 0, animated: true });
   };
 
+  const saveEntryMutation = useMutation({
+    mutationFn: async (entry: EntryWithProfile) => {
+      if (!entry.content_url) {
+        throw new Error('This entry has no media to save.');
+      }
 
-  const renderContent = () => {
-    if (error) {
-      return (
-        <View style={styles.errorContainer}>
-          <Text style={styles.errorTitle}>Unable to Load Entries</Text>
-          <Text style={styles.errorMessage}>{error.message || 'Something went wrong'}</Text>
-          <TouchableOpacity style={styles.retryButton} onPress={refetch}>
-            <Text style={styles.retryButtonText}>Try Again</Text>
-          </TouchableOpacity>
-        </View>
-      );
+      const extension = entry.type === 'video' ? 'mp4' : 'jpg';
+      const fileName = `${entry.id}.${extension}`;
+      const fileUri = `${FileSystem.cacheDirectory}${fileName}`;
+      const downloadResult = await FileSystem.downloadAsync(entry.content_url, fileUri);
+
+      if (downloadResult.status !== 200) {
+        throw new Error('Failed to download this entry.');
+      }
+
+      if (!await Sharing.isAvailableAsync()) {
+        throw new Error('Sharing is not available on this device.');
+      }
+
+      await Sharing.shareAsync(downloadResult.uri, { dialogTitle: 'Save to Photos' });
+    },
+    onSuccess: () => {
+      toast('Use Save Image/Video from the share sheet to add this entry to your library.');
+    },
+    onError: (mutationError: Error) => {
+      toast(mutationError.message || 'Unable to save this entry.', 'error');
+    },
+  });
+
+  const handleSaveEntry = () => {
+    if (!actionEntry) return;
+
+    saveEntryMutation.mutate(actionEntry);
+    setActionEntry(null);
+  };
+
+  const handleReportEntry = () => {
+    if (!actionEntry?.id) {
+      setActionEntry(null);
+      router.replace('/vault');
+      return;
     }
 
-    if (isLoading) {
-      return (
-        <View style={styles.loadingContainer}>
-          <ActivityIndicator size="large" color="#8B5CF6" />
-          <Text style={styles.loadingText}>Loading your entries...</Text>
-        </View>
-      );
-    }
-
-    if (!entries || entries.length === 0) {
-      return (
-        <View style={styles.emptyContainer}>
-          <Text style={styles.emptyText}>No entries yet</Text>
-          <Text style={styles.emptySubtext}>Start capturing moments to see them here</Text>
-          <TouchableOpacity
-            style={styles.captureButton}
-            onPress={() => router.back()}
-          >
-            <Text style={styles.captureButtonText}>Start Capturing</Text>
-          </TouchableOpacity>
-        </View>
-      );
-    }
-
-    return (
-      <EntryPage>
-        <Pressable
-          style={styles.backButton}
-          onPress={() => router.back()}
-        >
-          <ChevronLeft color="#64748B" size={24} />
-        </Pressable>
-        <Pressable
-          style={styles.sparklesButton}
-          onPress={() => router.push('/search')}
-        >
-          <Sparkles color="#64748B" size={24} />
-        </Pressable>
-        <FlashList
-          ref={flashListRef}
-          data={entriesByDate ? Object.keys(entriesByDate) : []}
-          contentContainerStyle={{
-            ...styles.contentContainer,
-            ...(responsive.isTablet && {
-              paddingHorizontal: responsive.contentPadding,
-              maxWidth: responsive.maxContentWidth,
-              alignSelf: 'center' as const,
-              width: '100%',
-            }),
-          }}
-          keyExtractor={(item) => item}
-          onScroll={handleScroll}
-          scrollEnabled={!isMusicPlayerVisible}
-          viewabilityConfig={viewabilityConfig}
-          onViewableItemsChanged={onViewableItemsChanged}
-          onEndReached={loadMore}
-          onEndReachedThreshold={0.5}
-          ListFooterComponent={() => (
-            isFetchingNextPage ? (
-              <View style={styles.footerLoading}>
-                <ActivityIndicator size="small" color="#8B5CF6" />
-              </View>
-            ) : null
-          )}
-          renderItem={({ item }) => {
-            const entries = entriesByDate?.[item];
-            if (!entries || entries.length === 0) {
-              return null;
-            }
-
-            // Convert date string to Date object, handling UTC conversion if needed
-            // item is a date string in YYYY-MM-DD format from groupBy
-            // We need to create a Date object for that date in local timezone
-            const dateString = item; // YYYY-MM-DD format
-            const [year, month, day] = dateString.split('-').map(Number);
-            const entriesDate = new Date(year, month - 1, day); // month is 0-indexed
-
-            if (isNaN(entriesDate.getTime())) {
-              return null;
-            }
-
-            return (
-              <View>
-                <View style={styles.listHeader}>
-                  <DateContainer date={entriesDate} />
-                </View>
-                {
-                  entries.map((entry) => {
-                    if (!entry?.id) {
-                      return null;
-                    }
-                    return (
-                      <VaultEntryCard
-                        entry={entry as any}
-                        key={entry.id}
-                        onReactions={handleEntryReactions}
-                        onComments={handleEntryComments}
-                        onRetry={retryEntry}
-                        onMusicPress={handleMusicPress}
-                      />
-                    );
-                  })
-                }
-              </View>
-            )
-          }}
-        />
-      </EntryPage>
+    Alert.alert(
+      'Report this entry?',
+      'Are you sure you want to report this diary entry?',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Report',
+          style: 'destructive',
+          onPress: () => {
+            const entryId = actionEntry.id;
+            setActionEntry(null);
+            router.push({ pathname: '/report-entry', params: { entryId } });
+          }
+        }
+      ]
     );
   };
 
+  if (error) {
+    return (
+      <View style={styles.errorContainer}>
+        <Text style={styles.errorTitle}>Unable to Load Entries</Text>
+        <Text style={styles.errorMessage}>{error.message || 'Something went wrong'}</Text>
+        <TouchableOpacity style={styles.retryButton} onPress={refetch}>
+          <Text style={styles.retryButtonText}>Try Again</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator size="large" color="#8B5CF6" />
+        <Text style={styles.loadingText}>Loading your entries...</Text>
+      </View>
+    );
+  }
+
+  if (!entries || entries.length === 0) {
+    return (
+      <View style={styles.emptyContainer}>
+        <Text style={styles.emptyText}>No entries yet</Text>
+        <Text style={styles.emptySubtext}>Start capturing moments to see them here</Text>
+        <TouchableOpacity
+          style={styles.captureButton}
+          onPress={() => router.back()}
+        >
+          <Text style={styles.captureButtonText}>Start Capturing</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
   return (
     <Animated.View style={styles.container}>
-      <>
-
-        <View style={styles.content}>
-          {renderContent()}
-        </View>
-
-        {/* New Entries Indicator */}
-        {unseenEntryIds.size > 0 && (
-          <NewEntriesIndicator
-            count={unseenEntryIds.size}
-            onPress={scrollToTop}
-            visible={unseenEntryIds.size > 0}
-          />
-        )}
-
-        {/* Popups at screen level */}
-        {isPopupVisible && selectedEntryId && (
-          <>
-            {popupType === 'reactions' && (
-              <EntryReactionsPopup
-                isVisible={true}
-                entryId={selectedEntryId}
-                onClose={hidePopup}
-              />
+      <View style={styles.content}>
+        <EntryPage>
+          <Pressable
+            style={styles.backButton}
+            onPress={() => router.back()}
+          >
+            <ChevronLeft color="#64748B" size={24} />
+          </Pressable>
+          <Pressable
+            style={styles.sparklesButton}
+            onPress={() => router.push('/search')}
+          >
+            <Sparkles color="#64748B" size={24} />
+          </Pressable>
+          <FlashList
+            ref={flashListRef}
+            data={entriesByDate ? Object.keys(entriesByDate) : []}
+            contentContainerStyle={{
+              ...styles.contentContainer,
+              ...(responsive.isTablet && {
+                paddingHorizontal: responsive.contentPadding,
+                maxWidth: responsive.maxContentWidth,
+                alignSelf: 'center' as const,
+                width: '100%',
+              }),
+            }}
+            keyExtractor={(item) => item}
+            scrollEnabled={!isMusicPlayerVisible}
+            viewabilityConfig={viewabilityConfig}
+            onViewableItemsChanged={onViewableItemsChanged}
+            onEndReached={loadMore}
+            onEndReachedThreshold={0.5}
+            ListFooterComponent={() => (
+              isFetchingNextPage ? (
+                <View style={styles.footerLoading}>
+                  <ActivityIndicator size="small" color="#8B5CF6" />
+                </View>
+              ) : null
             )}
-            {popupType === 'comments' && (
-              <EntryCommentsPopup
-                isVisible={true}
-                entryId={selectedEntryId}
-                onClose={hidePopup}
-              />
-            )}
-          </>
-        )}
+            renderItem={({ item }) => {
+              const dateEntries = entriesByDate?.[item];
+              if (!dateEntries || dateEntries.length === 0) {
+                return null;
+              }
 
-        {/* Music Player Popover at screen level */}
-        {selectedMusic && (
-          <AudioPreviewPopover
-            music={selectedMusic}
-            isVisible={isMusicPlayerVisible}
-            onClose={closeMusicPlayer}
+              const [year, month, day] = item.split('-').map(Number);
+              const entriesDate = new Date(year, month - 1, day);
+              if (isNaN(entriesDate.getTime())) return null;
+
+              return (
+                <View>
+                  <View style={styles.listHeader}>
+                    <DateContainer date={entriesDate} />
+                  </View>
+                  {dateEntries.map((entry) => {
+                    if (!entry?.id) return null;
+
+                    return (
+                      <VaultEntryCard
+                        entry={entry as EntryWithProfile}
+                        key={entry.id}
+                        onRetry={retryEntry}
+                        onMusicPress={handleMusicPress}
+                        onLongPress={setActionEntry}
+                      />
+                    );
+                  })}
+                </View>
+              );
+            }}
           />
-        )}
-      </>
+        </EntryPage>
+      </View>
+
+      {unseenEntryIds.size > 0 && (
+        <NewEntriesIndicator
+          count={unseenEntryIds.size}
+          onPress={scrollToTop}
+          visible={unseenEntryIds.size > 0}
+        />
+      )}
+
+      {isPopupVisible && selectedEntryId && (
+        <>
+          {popupType === 'reactions' && (
+            <EntryReactionsPopup
+              isVisible={true}
+              entryId={selectedEntryId}
+              onClose={hidePopup}
+            />
+          )}
+          {popupType === 'comments' && (
+            <EntryCommentsPopup
+              isVisible={true}
+              entryId={selectedEntryId}
+              onClose={hidePopup}
+            />
+          )}
+        </>
+      )}
+
+      {selectedMusic && (
+        <AudioPreviewPopover
+          music={selectedMusic}
+          isVisible={isMusicPlayerVisible}
+          onClose={closeMusicPlayer}
+        />
+      )}
+
+      <VaultEntryActionPopover
+        isVisible={!!actionEntry}
+        creatorName={actionEntry?.profile?.full_name || 'Unknown User'}
+        onClose={() => setActionEntry(null)}
+        onSave={handleSaveEntry}
+        onReport={handleReportEntry}
+      />
     </Animated.View>
   );
 }
@@ -330,7 +336,6 @@ const styles = StyleSheet.create({
   listHeader: {
     justifyContent: 'center',
     alignItems: 'center',
-    display: 'flex',
     flexDirection: 'row',
     marginVertical: verticalScale(24)
   },
@@ -430,181 +435,6 @@ const styles = StyleSheet.create({
     color: 'white',
     fontSize: 16,
     fontWeight: '600',
-  },
-  entryContainer: {
-    flex: 1,
-    paddingHorizontal: 20,
-    paddingTop: 20,
-  },
-  dateContainer: {
-    backgroundColor: 'white',
-    paddingHorizontal: 16,
-    paddingVertical: 8,
-    borderRadius: 20,
-    alignSelf: 'center',
-    marginBottom: 20,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.05,
-    shadowRadius: 4,
-    elevation: 2,
-  },
-  dateText: {
-    fontSize: 16,
-    color: '#1E293B',
-    fontWeight: '500',
-  },
-  entryCard: {
-    backgroundColor: 'white',
-    borderRadius: 24,
-    overflow: 'hidden',
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 8 },
-    shadowOpacity: 0.1,
-    shadowRadius: 16,
-    elevation: 8,
-    flex: 1,
-    maxHeight: height * 0.6,
-  },
-  entryImage: {
-    width: '100%',
-    height: 300,
-  },
-  audioContainer: {
-    height: 300,
-    backgroundColor: '#F8FAFC',
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  audioPlayButton: {
-    width: 80,
-    height: 80,
-    borderRadius: 40,
-    backgroundColor: 'white',
-    justifyContent: 'center',
-    alignItems: 'center',
-    marginBottom: 20,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.1,
-    shadowRadius: 8,
-    elevation: 4,
-  },
-  audioWave: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    height: 60,
-  },
-  waveBar: {
-    width: 4,
-    backgroundColor: '#8B5CF6',
-    marginHorizontal: 2,
-    borderRadius: 2,
-  },
-  entryContent: {
-    padding: 24,
-    flex: 1,
-  },
-  entryText: {
-    fontSize: 18,
-    color: '#1E293B',
-    lineHeight: 26,
-    marginBottom: 16,
-  },
-  entryMeta: {
-    marginBottom: 20,
-    gap: 8,
-  },
-  musicTag: {
-    fontSize: 16,
-    color: '#8B5CF6',
-    fontWeight: '500',
-  },
-  locationTag: {
-    fontSize: 16,
-    color: '#059669',
-    fontWeight: '500',
-  },
-  privateTag: {
-    fontSize: 16,
-    color: '#DC2626',
-    fontWeight: '500',
-  },
-  actionsContainer: {
-    flexDirection: 'row',
-    paddingTop: 20,
-    borderTopWidth: 1,
-    borderTopColor: '#F1F5F9',
-    gap: 32,
-  },
-  actionButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-  },
-  actionText: {
-    fontSize: 16,
-    color: '#64748B',
-    fontWeight: '500',
-  },
-  authorContainer: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    backgroundColor: 'white',
-    borderRadius: 20,
-    paddingHorizontal: 20,
-    paddingVertical: 16,
-    marginTop: 20,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.05,
-    shadowRadius: 8,
-    elevation: 2,
-  },
-  authorAvatar: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
-    marginRight: 12,
-  },
-  authorName: {
-    fontSize: 16,
-    fontWeight: '600',
-    color: '#1E293B',
-  },
-  navigationContainer: {
-    alignItems: 'center',
-    marginTop: 20,
-    marginBottom: 20,
-  },
-  progressIndicator: {
-    backgroundColor: 'white',
-    paddingHorizontal: 16,
-    paddingVertical: 8,
-    borderRadius: 16,
-    marginBottom: 12,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.05,
-    shadowRadius: 4,
-    elevation: 2,
-  },
-  progressText: {
-    fontSize: 14,
-    color: '#64748B',
-    fontWeight: '500',
-  },
-  swipeHint: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 4,
-    marginTop: 8,
-  },
-  swipeHintText: {
-    fontSize: 12,
-    color: '#94A3B8',
-    fontWeight: '500',
   },
   footerLoading: {
     paddingVertical: verticalScale(20),

--- a/frontend/app/vault.tsx
+++ b/frontend/app/vault.tsx
@@ -22,6 +22,7 @@ import { EntryWithProfile } from '@/types/entries';
 import * as FileSystem from 'expo-file-system/legacy';
 import * as Sharing from 'expo-sharing';
 import { useMutation } from '@tanstack/react-query';
+import { logger } from '@/lib/logger';
 import VaultEntryActionPopover from '@/components/vault/vault-entry-action-popover';
 
 const MUSIC_PLAYER_ANIMATION_DURATION = 300;
@@ -125,17 +126,26 @@ export default function VaultScreen() {
       const extension = typeToExtension[entry.type] || safeExtension || 'bin';
       const fileName = `${entry.id}.${extension}`;
       const fileUri = `${FileSystem.cacheDirectory}${fileName}`;
-      const downloadResult = await FileSystem.downloadAsync(entry.content_url, fileUri);
 
-      if (downloadResult.status !== 200) {
-        throw new Error('Failed to download this entry.');
+      try {
+        const downloadResult = await FileSystem.downloadAsync(entry.content_url, fileUri);
+
+        if (downloadResult.status !== 200) {
+          throw new Error('Failed to download this entry.');
+        }
+
+        if (!await Sharing.isAvailableAsync()) {
+          throw new Error('Sharing is not available on this device.');
+        }
+
+        await Sharing.shareAsync(downloadResult.uri, { dialogTitle: 'Save to Photos' });
+      } finally {
+        try {
+          await FileSystem.deleteAsync(fileUri, { idempotent: true });
+        } catch (cleanupError) {
+          logger.warn('Unable to clean temporary entry media file', cleanupError);
+        }
       }
-
-      if (!await Sharing.isAvailableAsync()) {
-        throw new Error('Sharing is not available on this device.');
-      }
-
-      await Sharing.shareAsync(downloadResult.uri, { dialogTitle: 'Save to Photos' });
     },
     onSuccess: () => {
       toast('Use Save Image/Video from the share sheet to add this entry to your library.');
@@ -219,12 +229,16 @@ export default function VaultScreen() {
           <Pressable
             style={styles.backButton}
             onPress={() => router.back()}
+            accessibilityLabel="Go back"
+            accessibilityHint="Returns to the previous screen"
           >
             <ChevronLeft color="#64748B" size={24} />
           </Pressable>
           <Pressable
             style={styles.sparklesButton}
             onPress={() => router.push('/search')}
+            accessibilityLabel="Open search"
+            accessibilityHint="Navigates to the search screen"
           >
             <Sparkles color="#64748B" size={24} />
           </Pressable>

--- a/frontend/app/vault.tsx
+++ b/frontend/app/vault.tsx
@@ -112,7 +112,17 @@ export default function VaultScreen() {
         throw new Error('This entry has no media to save.');
       }
 
-      const extension = entry.type === 'video' ? 'mp4' : 'jpg';
+      const typeToExtension: Record<string, string> = {
+        video: 'mp4',
+        audio: 'mp3',
+        photo: 'jpg',
+        image: 'jpg',
+      };
+
+      const parsedUrl = entry.content_url.split('?')[0] || '';
+      const derivedExtension = parsedUrl.includes('.') ? parsedUrl.split('.').pop()?.toLowerCase() : '';
+      const safeExtension = derivedExtension && /^[a-z0-9]+$/.test(derivedExtension) ? derivedExtension : '';
+      const extension = typeToExtension[entry.type] || safeExtension || 'bin';
       const fileName = `${entry.id}.${extension}`;
       const fileUri = `${FileSystem.cacheDirectory}${fileName}`;
       const downloadResult = await FileSystem.downloadAsync(entry.content_url, fileUri);

--- a/frontend/components/entries/vault-entry-card.tsx
+++ b/frontend/components/entries/vault-entry-card.tsx
@@ -1,40 +1,24 @@
 import React, { useMemo } from 'react';
-import { View, Text, TouchableOpacity, StyleSheet, Dimensions, Pressable, ActivityIndicator } from 'react-native';
+import { View, Text, StyleSheet, Dimensions, TouchableOpacity, ActivityIndicator, Pressable } from 'react-native';
 import Animated, { FadeIn, FadeOut, useAnimatedStyle } from 'react-native-reanimated';
-import { Heart, MessageCircle, Play, Pause, RotateCcw, AlertCircle, CheckCircle } from 'lucide-react-native';
-import { Audio } from 'expo-av';
-import { Database } from '@/types/database';
+import { RotateCcw, AlertCircle } from 'lucide-react-native';
 import { dateStringToNumber, getDefaultAvatarUrl, getRelativeDate } from '@/lib/utils';
 import { useAuthContext } from '@/providers/auth-provider';
 import { Image } from 'expo-image'
-import { useVideoPlayer, VideoView } from 'expo-video';
-import { useEvent } from 'expo';
 import VaultCanvas from '../capture/canvas/vault-canvas';
 import { scale, verticalScale } from 'react-native-size-matters';
 import { Colors } from '@/lib/constants';
 import TextTicker from 'react-native-text-ticker';
 import { MusicTag } from '@/types/capture';
 
-type Entry = Database['public']['Tables']['entries']['Row'];
-type Profile = Database['public']['Tables']['profiles']['Row'];
-
-interface EntryWithProfile extends Entry {
-  profile: Omit<Profile, "invite_code" | "max_uses" | "current_uses" | "is_active">;
-  status?: 'pending' | 'processing' | 'completed' | 'failed';
-  processingStartedAt?: string;
-  processingCompletedAt?: string;
-  processingFailedAt?: string;
-  error?: string;
-}
+import { EntryWithProfile } from '@/types/entries';
 
 interface VaultEntryCardProps {
   entry: EntryWithProfile;
   includeRotation?: boolean;
-  onPress?: (entry: EntryWithProfile) => void;
-  onReactions?: (entryId: string) => void;
-  onComments?: (entryId: string) => void;
   onRetry?: (entryId: string) => void;
   onMusicPress?: (music: MusicTag) => void;
+  onLongPress?: (entry: EntryWithProfile) => void;
 }
 
 const { height } = Dimensions.get('window');
@@ -42,34 +26,18 @@ const { height } = Dimensions.get('window');
 export default function VaultEntryCard({
   entry,
   includeRotation = true,
-  onPress,
-  onReactions,
-  onComments,
   onRetry,
   onMusicPress,
+  onLongPress,
 }: VaultEntryCardProps) {
-
   const numberHash = useMemo(() => {
     return dateStringToNumber(entry.created_at);
-  }, [])
-
-
+  }, [entry.created_at]);
 
   const { profile } = useAuthContext();
 
-  const handleEntryReactions = (e: any) => {
-    e.stopPropagation();
-    onReactions?.(entry.id);
-  };
-
-  const handleEntryComments = (e: any) => {
-    e.stopPropagation();
-    onComments?.(entry.id);
-  };
-
   const rotateStyle = useAnimatedStyle(() => {
-    // Generate a random angle between -6 and 6 degrees
-    const angle = numberHash * 12 - 6; // (-6 to 6)
+    const angle = numberHash * 12 - 6;
     return {
       transform: [{ rotate: `${angle}deg` }]
     };
@@ -114,7 +82,6 @@ export default function VaultEntryCard({
     }
   };
 
-  // Derive a safe profile for display to avoid undefined access during async swaps
   const safeProfile = useMemo(() => {
     if (entry?.profile) return entry.profile as any;
     if (profile && entry?.user_id === profile.id) {
@@ -127,67 +94,45 @@ export default function VaultEntryCard({
     } as any;
   }, [entry?.profile, entry?.user_id, profile]);
 
-
   return (
     <View style={styles.container}>
-      <Animated.View
-        style={includeRotation ? [styles.entryCard, rotateStyle] : styles.entryCard}
-        entering={FadeIn.duration(200)}
-        exiting={FadeOut.duration(150)}
-      >
-        <VaultCanvas
-          type={entry.type}
-          items={entry.attachments}
-          uri={entry.content_url || ''}
-          style={styles.entryImage as any}
-          onMusicPress={onMusicPress}
-          metadata={entry.metadata}
-        />
-
-        {/* Status indicator */}
-        {getStatusIndicator()}
-
-        {/* Author info at bottom */}
-        <View style={styles.authorContainer}>
-          <Image
-            source={{
-              uri: safeProfile?.avatar_url || getDefaultAvatarUrl(safeProfile?.full_name || '')
-            }}
-            style={styles.authorAvatar}
+      <Pressable onLongPress={() => onLongPress?.(entry)} delayLongPress={350}>
+        <Animated.View
+          style={includeRotation ? [styles.entryCard, rotateStyle] : styles.entryCard}
+          entering={FadeIn.duration(200)}
+          exiting={FadeOut.duration(150)}
+        >
+          <VaultCanvas
+            type={entry.type}
+            items={entry.attachments}
+            uri={entry.content_url || ''}
+            style={styles.entryImage as any}
+            onMusicPress={onMusicPress}
+            metadata={entry.metadata}
           />
-          <View style={styles.authorNameContainer}>
-            <TextTicker loop duration={5000} style={styles.authorName}>
-              {safeProfile?.id === profile?.id ? 'You' : safeProfile?.full_name || 'Unknown User'}
-            </TextTicker>
+
+          {getStatusIndicator()}
+
+          <View style={styles.authorContainer}>
+            <Image
+              source={{
+                uri: safeProfile?.avatar_url || getDefaultAvatarUrl(safeProfile?.full_name || '')
+              }}
+              style={styles.authorAvatar}
+            />
+            <View style={styles.authorNameContainer}>
+              <TextTicker loop duration={5000} style={styles.authorName}>
+                {safeProfile?.id === profile?.id ? 'You' : safeProfile?.full_name || 'Unknown User'}
+              </TextTicker>
+            </View>
+
+            <Text style={styles.dateText}>{getRelativeDate(entry.created_at)}</Text>
           </View>
-
-          <Text style={styles.dateText}>{getRelativeDate(entry.created_at)}</Text>
-        </View>
-      </Animated.View>
-
-      {/* <View style={styles.actionsContainer}>
-            <TouchableOpacity 
-              style={styles.actionButton} 
-              onPress={handleEntryReactions}
-            >
-              <Heart color="#64748B" size={20} />
-              <Text style={styles.actionText}>React</Text>
-            </TouchableOpacity>
-            
-            <TouchableOpacity 
-              style={styles.actionButton} 
-              onPress={handleEntryComments}
-            >
-              <MessageCircle color="#64748B" size={20} />
-              <Text style={styles.actionText}>Comment</Text>
-            </TouchableOpacity>
-          </View>
-       */}
-
+        </Animated.View>
+      </Pressable>
     </View>
   );
 }
-
 
 const styles = StyleSheet.create({
   container: {
@@ -196,115 +141,6 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'center',
     paddingVertical: 18
-  },
-  header: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    paddingHorizontal: 20,
-    paddingVertical: 16,
-    backgroundColor: '#F0F9FF',
-  },
-  title: {
-    fontSize: 20,
-    fontWeight: '600',
-    color: '#1E293B',
-  },
-  closeButton: {
-    padding: 8,
-  },
-  content: {
-    flex: 1,
-  },
-  loadingContainer: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  loadingText: {
-    fontSize: 16,
-    color: '#64748B',
-    marginTop: 16,
-  },
-  errorContainer: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    paddingHorizontal: 32,
-  },
-  errorTitle: {
-    fontSize: 20,
-    fontWeight: '600',
-    color: '#1E293B',
-    marginBottom: 8,
-    textAlign: 'center',
-  },
-  errorMessage: {
-    fontSize: 16,
-    color: '#64748B',
-    textAlign: 'center',
-    lineHeight: 22,
-    marginBottom: 24,
-  },
-  retryButton: {
-    backgroundColor: '#8B5CF6',
-    paddingHorizontal: 24,
-    paddingVertical: 12,
-    borderRadius: 12,
-  },
-  retryButtonText: {
-    color: 'white',
-    fontSize: 16,
-    fontWeight: '600',
-  },
-  emptyContainer: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    paddingHorizontal: 32,
-  },
-  emptyText: {
-    fontSize: 20,
-    fontWeight: '600',
-    color: '#1E293B',
-    marginBottom: 8,
-    textAlign: 'center',
-  },
-  emptySubtext: {
-    fontSize: 16,
-    color: '#64748B',
-    textAlign: 'center',
-    lineHeight: 22,
-    marginBottom: 24,
-  },
-  captureButton: {
-    backgroundColor: '#8B5CF6',
-    paddingHorizontal: 24,
-    paddingVertical: 12,
-    borderRadius: 12,
-  },
-  captureButtonText: {
-    color: 'white',
-    fontSize: 16,
-    fontWeight: '600',
-  },
-  entryContainer: {
-    flex: 1,
-    paddingHorizontal: 20,
-    paddingTop: 20,
-  },
-  dateContainer: {
-    backgroundColor: 'white',
-    paddingHorizontal: 16,
-    paddingVertical: 8,
-    borderRadius: 20,
-    alignSelf: 'center',
-    marginBottom: 20,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.05,
-    shadowRadius: 4,
-    elevation: 2,
   },
   dateText: {
     fontSize: scale(12),
@@ -331,54 +167,6 @@ const styles = StyleSheet.create({
     width: '100%',
     height: 300,
     borderRadius: 0
-  },
-
-
-  entryContent: {
-    flex: 1,
-  },
-  entryText: {
-    fontSize: 18,
-    color: '#1E293B',
-    lineHeight: 26,
-    marginBottom: 16,
-  },
-  entryMeta: {
-    marginBottom: 20,
-    gap: 8,
-  },
-  musicTag: {
-    fontSize: 16,
-    color: '#8B5CF6',
-    fontWeight: '500',
-  },
-  locationTag: {
-    fontSize: 16,
-    color: '#059669',
-    fontWeight: '500',
-  },
-  privateTag: {
-    fontSize: 16,
-    color: '#DC2626',
-    fontWeight: '500',
-  },
-  actionsContainer: {
-    flexDirection: 'row',
-    marginTop: 20,
-    paddingTop: 20,
-    borderTopWidth: 1,
-    borderTopColor: '#F1F5F9',
-    gap: 32,
-  },
-  actionButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-  },
-  actionText: {
-    fontSize: 16,
-    color: '#64748B',
-    fontWeight: '500',
   },
   authorContainer: {
     flexDirection: 'row',

--- a/frontend/components/friends/friends-header.tsx
+++ b/frontend/components/friends/friends-header.tsx
@@ -1,51 +1,10 @@
 import React from 'react';
-import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
-import { ChevronRight } from 'lucide-react-native';
-import { router } from 'expo-router';
-import { scale, verticalScale } from 'react-native-size-matters';
+import PageHeader from '@/components/page-header';
 
 interface FriendsHeaderProps {
-    title: string;
+  title: string;
 }
 
-/**
- * Header component for the Friends screen.
- * Uses ES5 function declaration for the component.
- */
-export function FriendsHeader(props: FriendsHeaderProps) {
-    const { title } = props;
-
-    return (
-        <View style={styles.header}>
-            <Text style={styles.title}>{title}</Text>
-            <TouchableOpacity
-                style={styles.closeButton}
-                onPress={function () { router.back(); }}
-            >
-                <ChevronRight color="#64748B" size={24} />
-            </TouchableOpacity>
-        </View>
-    );
+export function FriendsHeader({ title }: FriendsHeaderProps) {
+  return <PageHeader title={title} backButtonPlacement="right" />;
 }
-
-const styles = StyleSheet.create({
-    header: {
-        flexDirection: 'row',
-        alignItems: 'center',
-        justifyContent: 'center',
-        paddingHorizontal: scale(20),
-        paddingVertical: verticalScale(12),
-        backgroundColor: '#F0F9FF',
-    },
-    title: {
-        fontSize: 20,
-        fontFamily: 'Outfit-SemiBold',
-        fontWeight: '600',
-        color: '#1E293B',
-    },
-    closeButton: {
-        position: 'absolute',
-        right: 20,
-        padding: 8,
-    },
-});

--- a/frontend/components/page-header.tsx
+++ b/frontend/components/page-header.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { ChevronLeft, ChevronRight } from 'lucide-react-native';
+import { router } from 'expo-router';
+import { scale, verticalScale } from 'react-native-size-matters';
+
+type BackButtonPlacement = 'left' | 'right';
+
+interface PageHeaderProps {
+  title: string;
+  backButtonPlacement?: BackButtonPlacement;
+}
+
+export default function PageHeader({
+  title,
+  backButtonPlacement = 'right',
+}: PageHeaderProps) {
+  const isLeftPlacement = backButtonPlacement === 'left';
+
+  return (
+    <View style={styles.header}>
+      <Text style={styles.title}>{title}</Text>
+      <TouchableOpacity
+        style={[
+          styles.backButton,
+          isLeftPlacement ? styles.leftPlacement : styles.rightPlacement,
+        ]}
+        onPress={() => router.back()}
+      >
+        {isLeftPlacement ? (
+          <ChevronLeft color="#64748B" size={24} />
+        ) : (
+          <ChevronRight color="#64748B" size={24} />
+        )}
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: scale(20),
+    paddingVertical: verticalScale(12),
+    backgroundColor: '#F0F9FF',
+  },
+  title: {
+    fontSize: 20,
+    fontFamily: 'Outfit-SemiBold',
+    fontWeight: '600',
+    color: '#1E293B',
+  },
+  backButton: {
+    position: 'absolute',
+    padding: 8,
+  },
+  leftPlacement: {
+    left: 20,
+  },
+  rightPlacement: {
+    right: 20,
+  },
+});

--- a/frontend/components/vault/vault-entry-action-popover.tsx
+++ b/frontend/components/vault/vault-entry-action-popover.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
-import Animated, { SlideInDown, SlideOutDown } from 'react-native-reanimated';
+import Animated, { runOnJS, SlideInDown, SlideOutDown } from 'react-native-reanimated';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import { verticalScale } from 'react-native-size-matters';
 import { Colors } from '@/lib/constants';
@@ -23,7 +23,7 @@ export default function VaultEntryActionPopover({
   const swipeDownGesture = Gesture.Pan()
     .onEnd((event) => {
       if (event.translationY > 100 && event.velocityY > 500) {
-        onClose();
+        runOnJS(onClose)();
       }
     });
 

--- a/frontend/components/vault/vault-entry-action-popover.tsx
+++ b/frontend/components/vault/vault-entry-action-popover.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import Animated, { SlideInDown, SlideOutDown } from 'react-native-reanimated';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import { verticalScale } from 'react-native-size-matters';
+import { Colors } from '@/lib/constants';
+
+interface VaultEntryActionPopoverProps {
+  isVisible: boolean;
+  creatorName: string;
+  onClose: () => void;
+  onSave: () => void;
+  onReport: () => void;
+}
+
+export default function VaultEntryActionPopover({
+  isVisible,
+  creatorName,
+  onClose,
+  onSave,
+  onReport,
+}: VaultEntryActionPopoverProps) {
+  const swipeDownGesture = Gesture.Pan()
+    .onEnd((event) => {
+      if (event.translationY > 100 && event.velocityY > 500) {
+        onClose();
+      }
+    });
+
+  if (!isVisible) return null;
+
+  return (
+    <Animated.View style={styles.overlay}>
+      <TouchableOpacity style={styles.backdrop} onPress={onClose} />
+
+      <GestureDetector gesture={swipeDownGesture}>
+        <Animated.View
+          style={styles.popover}
+          entering={SlideInDown.duration(300).springify().damping(27).stiffness(90)}
+          exiting={SlideOutDown.duration(300).springify().damping(20).stiffness(90)}
+        >
+          <View style={styles.handle} />
+
+          <Text style={styles.title}>Take Action</Text>
+          <Text style={styles.description}>
+            What do you want to do with this diary entry from {creatorName}?
+          </Text>
+
+          <TouchableOpacity style={styles.saveButton} onPress={onSave}>
+            <Text style={styles.saveButtonText}>Save</Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity style={styles.reportButton} onPress={onReport}>
+            <Text style={styles.reportButtonText}>Report</Text>
+          </TouchableOpacity>
+        </Animated.View>
+      </GestureDetector>
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    position: 'absolute',
+    top: verticalScale(-50),
+    left: 0,
+    right: 0,
+    bottom: 0,
+    zIndex: 1000,
+  },
+  backdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.35)',
+  },
+  popover: {
+    position: 'absolute',
+    bottom: verticalScale(-40),
+    left: 0,
+    right: 0,
+    backgroundColor: Colors.white,
+    borderTopLeftRadius: 24,
+    borderTopRightRadius: 24,
+    paddingHorizontal: 20,
+    paddingTop: verticalScale(20),
+    paddingBottom: verticalScale(80),
+    gap: verticalScale(12),
+  },
+  handle: {
+    width: 40,
+    height: 4,
+    backgroundColor: '#E5E7EB',
+    borderRadius: 2,
+    alignSelf: 'center',
+    marginBottom: verticalScale(12),
+  },
+  title: {
+    fontSize: 20,
+    color: Colors.text,
+    fontFamily: 'Jost-SemiBold',
+  },
+  description: {
+    fontSize: 15,
+    color: '#475569',
+    marginBottom: verticalScale(8),
+    fontFamily: 'Jost-Regular',
+  },
+  saveButton: {
+    backgroundColor: Colors.primary,
+    borderRadius: 12,
+    paddingVertical: verticalScale(14),
+    alignItems: 'center',
+  },
+  saveButtonText: {
+    color: Colors.white,
+    fontSize: 16,
+    fontFamily: 'Jost-SemiBold',
+  },
+  reportButton: {
+    backgroundColor: '#E2E8F0',
+    borderRadius: 12,
+    paddingVertical: verticalScale(14),
+    alignItems: 'center',
+  },
+  reportButtonText: {
+    color: '#DC2626',
+    fontSize: 16,
+    fontFamily: 'Jost-SemiBold',
+  },
+});


### PR DESCRIPTION
### Motivation
- Provide a way for users to report a diary entry and take actions (save/report) from the Vault UI.
- Surface a common header component to unify page top bars across screens.
- Improve Vault UX by supporting long-press actions, saving media via share sheet, and cleaning up viewability/animation handling.

### Description
- Added a new reporting screen `report-entry.tsx` that collects a reason, removes the entry from device storage via `deviceStorage.removeEntry`, and navigates back to `/vault` after success.
- Registered the new route in the app layout by adding a `Stack.Screen` for `report-entry` in `_layout.tsx`.
- Introduced a reusable `PageHeader` component (`components/page-header.tsx`) and refactored `FriendsHeader` to use it.
- Added `VaultEntryActionPopover` (`components/vault/vault-entry-action-popover.tsx`) to present Save/Report actions and integrated it into the Vault screen.
- Extended `vault.tsx` to track `actionEntry`, handle long-press to open the action popover, implement save flow using `expo-file-system` download + `expo-sharing`, implement report flow that routes to the new `report-entry` screen, and simplified/cleaned up scroll/viewability and music-player cleanup logic.
- Updated `vault-entry-card.tsx` to accept `onLongPress` and wrap the card in a `Pressable` to trigger the action popover, and removed unused/commented legacy code.
- Minor UI/style adjustments and dependency imports added for sharing/filing and toasts.

### Testing
- TypeScript typecheck using `tsc` completed successfully.
- Linting via `yarn lint` completed successfully.
- Project unit tests invoked via `yarn test` ran and passed (no regressions reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a80d20d934832a9472f6981e79342d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Report diary entries via a dedicated report screen with selectable reasons
  * Save and share media from diary entries
  * Long-press on entries to open an action popover with Save/Report

* **UI/UX Improvements**
  * Streamlined vault layout with improved loading/empty/error states and grouped entries by date
  * New consistent page header with configurable back-button placement
  * Animated action popover for quick actions

* **Refactor**
  * Simplified entry card and vault rendering for clearer interactions and fewer inline controls
<!-- end of auto-generated comment: release notes by coderabbit.ai -->