### PR TITLE
Add Supabase migration to create public.entry_reports table with RLS

### DIFF
--- a/frontend/supabase/migrations/20260304120000_create_entry_reports.sql
+++ b/frontend/supabase/migrations/20260304120000_create_entry_reports.sql
@@ -1,0 +1,35 @@
+-- Create entry_reports table for users to report entries.
+create table if not exists public.entry_reports (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references public.profiles(id) on delete cascade,
+  entry_id uuid not null references public.entries(id) on delete cascade,
+  reason text not null,
+  created_at timestamptz not null default now(),
+  unique (user_id, entry_id)
+);
+
+create index if not exists entry_reports_user_id_idx
+on public.entry_reports (user_id);
+
+create index if not exists entry_reports_entry_id_idx
+on public.entry_reports (entry_id);
+
+alter table public.entry_reports enable row level security;
+
+create policy "Users can view their own entry reports"
+on public.entry_reports
+for select
+to authenticated
+using (auth.uid() = user_id);
+
+create policy "Users can insert their own entry reports"
+on public.entry_reports
+for insert
+to authenticated
+with check (auth.uid() = user_id);
+
+create policy "Users can delete their own entry reports"
+on public.entry_reports
+for delete
+to authenticated
+using (auth.uid() = user_id);


### PR DESCRIPTION
### Motivation
- Add a new table to track user reports of entries, enforce one report per user per entry, and follow existing schema and RLS conventions.
- Ensure foreign keys use fully-qualified names and indexes exist for expected query patterns for `user_id` and `entry_id`.

### Description
- Added `frontend/supabase/migrations/20260304120000_create_entry_reports.sql` which creates `public.entry_reports` with `id uuid primary key default gen_random_uuid()`, `user_id uuid not null references public.profiles(id) on delete cascade`, `entry_id uuid not null references public.entries(id) on delete cascade`, `reason text not null`, and `created_at timestamptz not null default now()`.
- Enforced uniqueness with `unique (user_id, entry_id)` to allow one report per user per entry.
- Created indexes `entry_reports_user_id_idx` and `entry_reports_entry_id_idx` on `user_id` and `entry_id` respectively.
- Enabled row level security on `public.entry_reports` and added policies so authenticated users can `select`, `insert`, and `delete` only rows where `auth.uid() = user_id`.

### Testing
- Verified repository changes with `git -C /workspace/keepsafe status --short` which showed the new migration file was staged and committed successfully.
- Inspected the created migration file with `nl -ba frontend/supabase/migrations/20260304120000_create_entry_reports.sql` to confirm the DDL, indexes, uniqueness constraint, and RLS policies were added as intended.
- Searched existing migrations with `rg` to confirm RLS and policy conventions and that foreign-key targets use `public.profiles` and `public.entries` consistently, with no errors reported by the searches.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a830184658832a82dbfe1792de2bd5)