### PR TITLE
Add tests for entry-report email & webhook; improve webhook logging and 500 on send failure

### DIFF
--- a/backend/routers/webhooks.py
+++ b/backend/routers/webhooks.py
@@ -331,6 +331,7 @@ async def entry_report_webhook(
 ):
     """Process entry report Supabase webhooks and send email notifications."""
     try:
+        logger.info("Entry report webhook request received")
         webhook_secret = settings.SUPABASE_WEBHOOK_SECRET
         if not webhook_secret:
             logger.error("SUPABASE_WEBHOOK_SECRET is not configured")
@@ -374,6 +375,7 @@ async def entry_report_webhook(
             },
         )
 
+        logger.info("Attempting entry report email dispatch")
         send_success = await run_in_threadpool(email_service.send_entry_report_email, report_payload)
         if not send_success:
             logger.error(
@@ -384,7 +386,9 @@ async def entry_report_webhook(
                     "user_id": report_payload.get("user_id"),
                 },
             )
-            raise HTTPException(status_code=502, detail="Failed to dispatch entry report email")
+            raise HTTPException(status_code=500, detail="Failed to dispatch entry report email")
+
+        logger.info("Entry report email dispatch succeeded")
 
         return {
             "status": "success",

--- a/backend/tests/test_email_service.py
+++ b/backend/tests/test_email_service.py
@@ -1,0 +1,133 @@
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import types
+
+
+def _install_sendgrid_stub() -> None:
+    sendgrid_module = types.ModuleType("sendgrid")
+    helpers_module = types.ModuleType("sendgrid.helpers")
+    mail_module = types.ModuleType("sendgrid.helpers.mail")
+
+    class SendGridAPIClient:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+    class Mail:
+        def __init__(self, from_email, to_emails, subject, plain_text_content):
+            email, name = from_email
+            self._payload = {
+                "from": {"email": email, "name": name},
+                "subject": subject,
+                "content": [{"value": plain_text_content}],
+                "personalizations": [{"to": [{"email": to_emails}]}],
+            }
+
+        def get(self):
+            return self._payload
+
+    sendgrid_module.SendGridAPIClient = SendGridAPIClient
+    mail_module.Mail = Mail
+
+    sys.modules.setdefault("sendgrid", sendgrid_module)
+    sys.modules.setdefault("sendgrid.helpers", helpers_module)
+    sys.modules.setdefault("sendgrid.helpers.mail", mail_module)
+
+
+try:
+    import sendgrid  # noqa: F401
+except ModuleNotFoundError:
+    _install_sendgrid_stub()
+
+CURRENT_DIR = os.path.dirname(__file__)
+BACKEND_DIR = os.path.abspath(os.path.join(CURRENT_DIR, os.pardir))
+if BACKEND_DIR not in sys.path:
+    sys.path.insert(0, BACKEND_DIR)
+
+from services.email_service import EmailService
+
+
+def test_send_entry_report_email_composes_payload_and_sends(monkeypatch):
+    monkeypatch.setattr("services.email_service.settings.SENDGRID_API_KEY", "sg-key", raising=False)
+    monkeypatch.setattr("services.email_service.settings.SENDGRID_FROM_EMAIL", "from@example.com", raising=False)
+    monkeypatch.setattr("services.email_service.settings.SENDGRID_FROM_NAME", "KeepSafe", raising=False)
+    monkeypatch.setattr(
+        "services.email_service.settings.ENTRY_REPORT_NOTIFICATION_TO_EMAIL",
+        "to@example.com",
+        raising=False,
+    )
+
+    mock_client = MagicMock()
+    mock_response = MagicMock(status_code=202)
+    mock_client.send.return_value = mock_response
+
+    with patch("services.email_service.SendGridAPIClient", return_value=mock_client):
+        service = EmailService()
+
+    payload = {
+        "id": "report-1",
+        "entry_id": "entry-9",
+        "user_id": "user-3",
+        "reason": "spam",
+    }
+
+    result = service.send_entry_report_email(payload)
+
+    assert result is True
+    mock_client.send.assert_called_once()
+
+    mail_obj = mock_client.send.call_args.args[0]
+    mail_payload = mail_obj.get()
+
+    assert mail_payload["from"] == {"email": "from@example.com", "name": "KeepSafe"}
+    assert mail_payload["subject"] == "New Entry Report Received (entry_id=entry-9)"
+    assert mail_payload["content"][0]["value"] == (
+        "A new entry report was received.\n\n"
+        "report_id: report-1\n"
+        "entry_id: entry-9\n"
+        "user_id: user-3\n"
+        "reason: spam\n"
+    )
+    assert mail_payload["personalizations"][0]["to"][0]["email"] == "to@example.com"
+
+
+def test_send_entry_report_email_logs_and_returns_false_on_send_exception(monkeypatch, caplog):
+    monkeypatch.setattr("services.email_service.settings.SENDGRID_API_KEY", "sg-key", raising=False)
+    monkeypatch.setattr("services.email_service.settings.SENDGRID_FROM_EMAIL", "from@example.com", raising=False)
+    monkeypatch.setattr("services.email_service.settings.SENDGRID_FROM_NAME", "KeepSafe", raising=False)
+    monkeypatch.setattr(
+        "services.email_service.settings.ENTRY_REPORT_NOTIFICATION_TO_EMAIL",
+        "to@example.com",
+        raising=False,
+    )
+
+    mock_client = MagicMock()
+    mock_client.send.side_effect = RuntimeError("send failed")
+
+    with patch("services.email_service.SendGridAPIClient", return_value=mock_client):
+        service = EmailService()
+
+    caplog.set_level("ERROR")
+    result = service.send_entry_report_email(
+        {"id": "report-2", "entry_id": "entry-2", "user_id": "user-2", "reason": "abuse"}
+    )
+
+    assert result is False
+    assert "Failed to send entry report email" in caplog.text
+    assert "SendGrid exception details: send failed" in caplog.text
+
+
+def test_send_entry_report_email_without_api_key_logs_and_returns_false(monkeypatch, caplog):
+    monkeypatch.setattr("services.email_service.settings.SENDGRID_API_KEY", "", raising=False)
+    monkeypatch.setattr("services.email_service.settings.ENTRY_REPORT_NOTIFICATION_TO_EMAIL", "to@example.com", raising=False)
+
+    service = EmailService()
+
+    caplog.set_level("ERROR")
+    result = service.send_entry_report_email(
+        {"id": "report-3", "entry_id": "entry-3", "user_id": "user-3", "reason": "fraud"}
+    )
+
+    assert result is False
+    assert "SendGrid API key is not configured; cannot send entry report email" in caplog.text

--- a/backend/tests/test_entry_report_webhook.py
+++ b/backend/tests/test_entry_report_webhook.py
@@ -1,0 +1,152 @@
+import hashlib
+import hmac
+import json
+import os
+import sys
+import types
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def _install_sendgrid_stub() -> None:
+    sendgrid_module = types.ModuleType("sendgrid")
+    helpers_module = types.ModuleType("sendgrid.helpers")
+    mail_module = types.ModuleType("sendgrid.helpers.mail")
+
+    class SendGridAPIClient:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+    class Mail:
+        def __init__(self, from_email, to_emails, subject, plain_text_content):
+            self.from_email = from_email
+            self.to_emails = to_emails
+            self.subject = subject
+            self.plain_text_content = plain_text_content
+
+    sendgrid_module.SendGridAPIClient = SendGridAPIClient
+    mail_module.Mail = Mail
+
+    sys.modules.setdefault("sendgrid", sendgrid_module)
+    sys.modules.setdefault("sendgrid.helpers", helpers_module)
+    sys.modules.setdefault("sendgrid.helpers.mail", mail_module)
+
+
+try:
+    import sendgrid  # noqa: F401
+except ModuleNotFoundError:
+    _install_sendgrid_stub()
+
+
+CURRENT_DIR = os.path.dirname(__file__)
+BACKEND_DIR = os.path.abspath(os.path.join(CURRENT_DIR, os.pardir))
+if BACKEND_DIR not in sys.path:
+    sys.path.insert(0, BACKEND_DIR)
+
+from routers import webhooks
+
+
+def _signed_headers(secret: str, body: bytes) -> dict:
+    signature = hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+    return {
+        "content-type": "application/json",
+        "x-supabase-signature": signature,
+    }
+
+
+def _valid_payload() -> dict:
+    return {
+        "type": "INSERT",
+        "table": "entry_reports",
+        "record": {
+            "id": "report-1",
+            "user_id": "user-1",
+            "entry_id": "entry-1",
+            "reason": "spam",
+        },
+    }
+
+
+def _build_client() -> TestClient:
+    app = FastAPI()
+    app.include_router(webhooks.router)
+    return TestClient(app)
+
+
+def test_entry_report_webhook_success(monkeypatch, caplog):
+    client = _build_client()
+    monkeypatch.setattr(webhooks.settings, "SUPABASE_WEBHOOK_SECRET", "test-secret", raising=False)
+
+    calls = []
+
+    def fake_send_email(report_payload):
+        calls.append(report_payload)
+        return True
+
+    monkeypatch.setattr(webhooks.email_service, "send_entry_report_email", fake_send_email)
+
+    payload = _valid_payload()
+    body = json.dumps(payload).encode("utf-8")
+    caplog.set_level("INFO")
+
+    response = client.post("/webhooks/entry-reports", content=body, headers=_signed_headers("test-secret", body))
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "success",
+        "message": "Entry report report-1 processed successfully",
+        "entry_report_id": "report-1",
+    }
+    assert calls == [payload["record"]]
+    assert "Entry report webhook request received" in caplog.text
+    assert "Attempting entry report email dispatch" in caplog.text
+    assert "Entry report email dispatch succeeded" in caplog.text
+
+
+def test_entry_report_webhook_validation_failure_missing_fields(monkeypatch):
+    client = _build_client()
+    monkeypatch.setattr(webhooks.settings, "SUPABASE_WEBHOOK_SECRET", "test-secret", raising=False)
+
+    called = False
+
+    def fake_send_email(_):
+        nonlocal called
+        called = True
+        return True
+
+    monkeypatch.setattr(webhooks.email_service, "send_entry_report_email", fake_send_email)
+
+    payload = {
+        "type": "INSERT",
+        "table": "entry_reports",
+        "record": {
+            "id": "report-2",
+            "user_id": "user-2",
+            "entry_id": "entry-2",
+        },
+    }
+    body = json.dumps(payload).encode("utf-8")
+
+    response = client.post("/webhooks/entry-reports", content=body, headers=_signed_headers("test-secret", body))
+
+    assert response.status_code == 422
+    assert called is False
+
+
+def test_entry_report_webhook_send_failure_returns_500(monkeypatch, caplog):
+    client = _build_client()
+    monkeypatch.setattr(webhooks.settings, "SUPABASE_WEBHOOK_SECRET", "test-secret", raising=False)
+    monkeypatch.setattr(webhooks.email_service, "send_entry_report_email", lambda _: False)
+
+    payload = _valid_payload()
+    body = json.dumps(payload).encode("utf-8")
+    caplog.set_level("INFO")
+
+    response = client.post("/webhooks/entry-reports", content=body, headers=_signed_headers("test-secret", body))
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "Failed to dispatch entry report email"
+    assert "Entry report webhook request received" in caplog.text
+    assert "Attempting entry report email dispatch" in caplog.text
+    assert "Entry report email dispatch failed" in caplog.text


### PR DESCRIPTION
### Motivation
- Validate `EmailService.send_entry_report_email` for correct SendGrid payload composition and robust failure handling and logging.
- Provide API-level coverage for the `/webhooks/entry-reports` route including signature validation, request validation, and send-failure handling without relying on external services or secrets.
- Improve webhook observability so key events are logged and the HTTP error semantics for email dispatch failures are consistent with integration expectations.

### Description
- Added unit tests in `backend/tests/test_email_service.py` that mock `SendGridAPIClient.send`, assert `from`, `to`, `subject`, and `body` composition, and verify failure-path logging and return values.
- Added integration tests in `backend/tests/test_entry_report_webhook.py` using FastAPI `TestClient` that monkeypatch the email send call and cover success, validation failure (missing fields), and send-failure (returns 500) paths with `caplog` assertions for key log events.
- Introduced small test-time SendGrid stubs inside the test files so tests do not require the real `sendgrid` package or environment secrets.
- Updated `backend/routers/webhooks.py` to log `Entry report webhook request received`, `Attempting entry report email dispatch`, and `Entry report email dispatch succeeded`, and changed the email-dispatch failure response status to `500`.

### Testing
- Ran `cd backend && pytest -q tests/test_email_service.py tests/test_entry_report_webhook.py` and the tests completed successfully with `6 passed, 1 warning`.
- The test suite exercises mocked `SendGridAPIClient.send`, webhook HMAC signature validation, and `caplog` assertions for the request received, email send attempted, and send success/failure events.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a84b1a2ef4832abc1e92b049030cf5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected HTTP error response code for entry report webhook failures to provide more accurate error reporting.

* **Tests**
  * Added comprehensive test coverage for email service, including success paths and error handling scenarios.
  * Added test coverage for entry report webhook functionality, including validation and failure handling.

* **Chores**
  * Enhanced debug logging for entry report webhook processing to track request lifecycle and outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->