### PR TITLE
Add ReportService and useReportedEntries hook; filter reported entries from Vault

### DIFF
--- a/frontend/app/report-entry.tsx
+++ b/frontend/app/report-entry.tsx
@@ -4,10 +4,10 @@ import { router, useLocalSearchParams } from 'expo-router';
 import { scale, verticalScale } from 'react-native-size-matters';
 import { Colors } from '@/lib/constants';
 import { useAuthContext } from '@/providers/auth-provider';
-import { useMutation } from '@tanstack/react-query';
 import { deviceStorage } from '@/services/device-storage';
 import { useToast } from '@/hooks/use-toast';
 import PageHeader from '@/components/page-header';
+import { useReportedEntries } from '@/hooks/use-reported-entries';
 
 const REPORT_REASONS = [
   'Harassment or bullying',
@@ -22,29 +22,13 @@ export default function ReportEntryScreen() {
   const { entryId } = useLocalSearchParams<{ entryId?: string }>();
   const { user } = useAuthContext();
   const { toast } = useToast();
+  const { createReportAsync, isCreatingReport } = useReportedEntries();
   const [selectedReason, setSelectedReason] = useState<string>('');
 
   const safeEntryId = useMemo(() => {
     if (!entryId || typeof entryId !== 'string') return '';
     return entryId;
   }, [entryId]);
-
-  const reportMutation = useMutation({
-    mutationFn: async () => {
-      if (!user?.id || !safeEntryId) {
-        throw new Error('Missing entry data for this report.');
-      }
-
-      await deviceStorage.removeEntry(user.id, safeEntryId);
-    },
-    onSuccess: () => {
-      toast('Entry reported. It has been removed from this device.');
-      router.replace('/vault');
-    },
-    onError: (error: Error) => {
-      toast(error.message || 'Unable to report this entry.', 'error');
-    }
-  });
 
   useEffect(() => {
     if (safeEntryId) return;
@@ -53,13 +37,26 @@ export default function ReportEntryScreen() {
 
   if (!safeEntryId) return null;
 
-  const handleConfirm = () => {
+  const handleConfirm = async () => {
     if (!selectedReason) {
       Alert.alert('Reason required', 'Please pick a reason before submitting your report.');
       return;
     }
 
-    reportMutation.mutate();
+    if (!user?.id || !safeEntryId) {
+      toast('Missing entry data for this report.', 'error');
+      return;
+    }
+
+    try {
+      await createReportAsync({ entryId: safeEntryId, reason: selectedReason });
+      await deviceStorage.removeEntry(user.id, safeEntryId);
+      toast('Entry reported. It has been removed from this device.');
+      router.replace('/vault');
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unable to report this entry.';
+      toast(errorMessage, 'error');
+    }
   };
 
   return (
@@ -83,11 +80,11 @@ export default function ReportEntryScreen() {
       </View>
 
       <TouchableOpacity
-        style={[styles.confirmButton, reportMutation.isPending && styles.confirmButtonDisabled]}
-        disabled={reportMutation.isPending}
+        style={[styles.confirmButton, isCreatingReport && styles.confirmButtonDisabled]}
+        disabled={isCreatingReport}
         onPress={handleConfirm}
       >
-        <Text style={styles.confirmButtonText}>{reportMutation.isPending ? 'Submitting...' : 'Confirm Report'}</Text>
+        <Text style={styles.confirmButtonText}>{isCreatingReport ? 'Submitting...' : 'Confirm Report'}</Text>
       </TouchableOpacity>
     </View>
   );

--- a/frontend/app/vault.tsx
+++ b/frontend/app/vault.tsx
@@ -24,6 +24,7 @@ import * as Sharing from 'expo-sharing';
 import { useMutation } from '@tanstack/react-query';
 import { logger } from '@/lib/logger';
 import VaultEntryActionPopover from '@/components/vault/vault-entry-action-popover';
+import { useReportedEntries } from '@/hooks/use-reported-entries';
 
 const MUSIC_PLAYER_ANIMATION_DURATION = 300;
 const MUSIC_PLAYER_CLEANUP_DELAY = MUSIC_PLAYER_ANIMATION_DURATION + 50;
@@ -31,6 +32,7 @@ const MUSIC_PLAYER_CLEANUP_DELAY = MUSIC_PLAYER_ANIMATION_DURATION + 50;
 export default function VaultScreen() {
   const responsive = useResponsive();
   const { toast } = useToast();
+  const { reportedPostIds } = useReportedEntries();
   const {
     entries,
     entriesByDate,
@@ -44,6 +46,14 @@ export default function VaultScreen() {
     loadMore,
   } = useUserEntries();
   const { selectedEntryId, popupType, isPopupVisible, hidePopup } = usePopupParams();
+  const reportedPostIdSet = new Set(reportedPostIds);
+  const filteredEntriesByDate: Record<string, EntryWithProfile[]> = Object.fromEntries(
+    Object.entries(entriesByDate || {}).map(([date, dateEntries]) => {
+      const visibleDateEntries = (dateEntries as EntryWithProfile[]).filter((entry) => !reportedPostIdSet.has(entry.id));
+      return [date, visibleDateEntries];
+    }).filter(([, dateEntries]) => dateEntries.length > 0)
+  ) as Record<string, EntryWithProfile[]>;
+  const visibleEntriesCount = Object.values(filteredEntriesByDate).reduce((count, dateEntries) => count + dateEntries.length, 0);
 
   const [selectedMusic, setSelectedMusic] = useState<MusicTag | null>(null);
   const [isMusicPlayerVisible, setIsMusicPlayerVisible] = useState(false);
@@ -92,7 +102,7 @@ export default function VaultScreen() {
 
     viewableItems.forEach(item => {
       const dateKey = item.item;
-      const dateEntries = entriesByDate?.[dateKey] || [];
+      const dateEntries = filteredEntriesByDate[dateKey] || [];
       dateEntries.forEach((entry: any) => {
         if (!unseenEntryIds.has(entry.id)) return;
         visibleEntryIds.push(entry.id);
@@ -101,7 +111,7 @@ export default function VaultScreen() {
 
     if (!visibleEntryIds.length) return;
     markEntriesAsSeen(visibleEntryIds);
-  }, [entriesByDate, unseenEntryIds, markEntriesAsSeen]);
+  }, [filteredEntriesByDate, unseenEntryIds, markEntriesAsSeen]);
 
   const scrollToTop = () => {
     flashListRef.current?.scrollToOffset({ offset: 0, animated: true });
@@ -207,7 +217,7 @@ export default function VaultScreen() {
     );
   }
 
-  if (!entries || entries.length === 0) {
+  if (!entries || visibleEntriesCount === 0) {
     return (
       <View style={styles.emptyContainer}>
         <Text style={styles.emptyText}>No entries yet</Text>
@@ -244,7 +254,7 @@ export default function VaultScreen() {
           </Pressable>
           <FlashList
             ref={flashListRef}
-            data={entriesByDate ? Object.keys(entriesByDate) : []}
+            data={Object.keys(filteredEntriesByDate)}
             contentContainerStyle={{
               ...styles.contentContainer,
               ...(responsive.isTablet && {
@@ -268,7 +278,7 @@ export default function VaultScreen() {
               ) : null
             )}
             renderItem={({ item }) => {
-              const dateEntries = entriesByDate?.[item];
+              const dateEntries = filteredEntriesByDate[item];
               if (!dateEntries || dateEntries.length === 0) {
                 return null;
               }

--- a/frontend/constants/supabase.ts
+++ b/frontend/constants/supabase.ts
@@ -14,6 +14,7 @@ export const TABLES = {
   PRIVACY_SETTINGS: 'privacy_settings',
   USER_STREAKS: 'user_streaks',
   PHONE_NUMBER_UPDATES: 'phone_number_updates',
+  ENTRY_REPORTS: 'entry_reports',
 } as const;
 
 // Storage Bucket Names

--- a/frontend/hooks/use-reported-entries.ts
+++ b/frontend/hooks/use-reported-entries.ts
@@ -1,0 +1,77 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useAuthContext } from '@/providers/auth-provider';
+import { ReportService } from '@/services/report-service';
+
+interface CreateReportInput {
+  entryId: string;
+  reason: string;
+}
+
+interface UseReportedEntriesResult {
+  reportedPostIds: string[];
+  isLoadingReportedPosts: boolean;
+  reportedPostsError: Error | null;
+  createReport: (input: CreateReportInput) => void;
+  createReportAsync: (input: CreateReportInput) => Promise<void>;
+  isCreatingReport: boolean;
+  createReportError: Error | null;
+}
+
+/**
+ * Provides access to reported entry IDs and mutation helpers for creating reports.
+ * Uses React Query for cached reads and optimistic mutation updates tied to the authenticated user.
+ */
+export function useReportedEntries(): UseReportedEntriesResult {
+  const { user } = useAuthContext();
+  const queryClient = useQueryClient();
+  const queryKey = ['reported-post-ids', user?.id];
+
+  const {
+    data: reportedPostIds = [],
+    isLoading: isLoadingReportedPosts,
+    error: reportedPostsError,
+  } = useQuery<string[]>({
+    queryKey,
+    enabled: !!user?.id,
+    queryFn: async () => {
+      if (!user?.id) return [];
+      return ReportService.getReportedPosts(user.id);
+    },
+  });
+
+  const createReportMutation = useMutation({
+    mutationFn: async ({ entryId, reason }: CreateReportInput) => {
+      if (!user?.id) {
+        throw new Error('Missing user data for this report.');
+      }
+
+      await ReportService.createReport(user.id, entryId, reason);
+    },
+    onMutate: async ({ entryId }: CreateReportInput) => {
+      await queryClient.cancelQueries({ queryKey });
+      const previous = queryClient.getQueryData<string[]>(queryKey) || [];
+      if (previous.includes(entryId)) {
+        return { previous };
+      }
+
+      queryClient.setQueryData<string[]>(queryKey, [...previous, entryId]);
+      return { previous };
+    },
+    onError: (_error, _variables, context) => {
+      queryClient.setQueryData<string[]>(queryKey, context?.previous || []);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey });
+    },
+  });
+
+  return {
+    reportedPostIds,
+    isLoadingReportedPosts,
+    reportedPostsError: reportedPostsError as Error | null,
+    createReport: createReportMutation.mutate,
+    createReportAsync: createReportMutation.mutateAsync,
+    isCreatingReport: createReportMutation.isPending,
+    createReportError: createReportMutation.error as Error | null,
+  };
+}

--- a/frontend/services/report-service.ts
+++ b/frontend/services/report-service.ts
@@ -1,0 +1,43 @@
+import { TABLES } from '@/constants/supabase';
+import { supabase } from '@/lib/supabase';
+import { deviceStorage } from '@/services/device-storage';
+
+const REPORTED_POSTS_STORAGE_KEY = (userId: string) => `reported_posts_${userId}`;
+
+export class ReportService {
+  static async createReport(userId: string, entryId: string, reason: string): Promise<void> {
+    const existingReports = await this.getReportedPosts(userId);
+    const nextReports = existingReports.includes(entryId) ? existingReports : [...existingReports, entryId];
+
+    await deviceStorage.setItem(REPORTED_POSTS_STORAGE_KEY(userId), nextReports);
+
+    const { error } = await supabase
+      .from(TABLES.ENTRY_REPORTS)
+      .upsert({ user_id: userId, entry_id: entryId, reason } as never, { onConflict: 'user_id,entry_id' } as never);
+
+    if (!error) return;
+    throw new Error(error.message || 'Failed to create report.');
+  }
+
+  static async getReportedPosts(userId: string): Promise<string[]> {
+    const localReports = await deviceStorage.getItem<string[]>(REPORTED_POSTS_STORAGE_KEY(userId));
+    if (localReports) {
+      return localReports;
+    }
+
+    const { data, error } = await supabase
+      .from(TABLES.ENTRY_REPORTS)
+      .select('entry_id')
+      .eq('user_id', userId);
+
+    if (error || !data) {
+      return [];
+    }
+
+    const reportedEntryIds = (data as Array<{ entry_id: string | null }>)
+      .map((report) => report.entry_id)
+      .filter((entryId): entryId is string => !!entryId);
+    await deviceStorage.setItem(REPORTED_POSTS_STORAGE_KEY(userId), reportedEntryIds);
+    return reportedEntryIds;
+  }
+}


### PR DESCRIPTION
### Motivation

- Persist user reports locally and to Supabase and prevent reported entries from showing in the Vault view.
- Centralize report creation and reported-IDs caching to avoid duplicating mutation logic in UI components.

### Description

- Added `ReportService` which persists reported entry IDs to `deviceStorage` and upserts reports to the new `ENTRY_REPORTS` Supabase table.
- Added `useReportedEntries` hook that exposes reported post IDs via React Query and a mutation with optimistic updates (`createReportAsync`, `isCreatingReport`, etc.).
- Updated `ReportEntryScreen` to use `useReportedEntries` for creating reports and to remove the entry from local storage after a successful report.
- Updated `VaultScreen` to consume reported IDs, filter out reported entries from `entriesByDate`, update viewability callbacks and list rendering, and handle empty-state counting using the filtered entries.
- Added `ENTRY_REPORTS` constant to `frontend/constants/supabase.ts`.

### Testing

- Ran TypeScript build (`yarn build` / `tsc`) to validate types and imports, and the build succeeded.
- Ran the existing automated test suite (`yarn test`), and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8cc117140832ab86c813d4b0b9eb7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Report entries for moderation review and provide a reason for your report.
  * Reported entries are automatically and instantly hidden from your vault.
  * Clear loading feedback when submitting reports.
  * All reports are securely tracked and stored on our servers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->