### PR TITLE
Update capture permission CTA text to Continue

### DIFF
--- a/frontend/app/capture/index.tsx
+++ b/frontend/app/capture/index.tsx
@@ -457,7 +457,7 @@ export default function CaptureScreen() {
         <View style={styles.permissionContainer}>
           <Text style={styles.permissionText}>We need camera permission to continue</Text>
           <TouchableOpacity style={styles.permissionButton} onPress={requestPermission}>
-            <Text style={styles.permissionButtonText}>Grant Permission</Text>
+            <Text style={styles.permissionButtonText}>Continue</Text>
           </TouchableOpacity>
         </View>
       </SafeAreaView>


### PR DESCRIPTION
### Motivation
- The capture page shows a first-time camera permission CTA labeled `Grant Permission`; this updates the copy to `Continue` for a softer prompt and keeps copy consistent if other instances exist.

### Description
- Replaced the button label in `frontend/app/capture/index.tsx` from `Grant Permission` to `Continue`, and searched `frontend/app`, `frontend/components`, and `frontend/hooks` for other matches and found none so only this file was changed.

### Testing
- Ran `git diff --check` which passed successfully.
- Ran `cd frontend && npm run lint` which failed due to the repository ESLint v9 configuration expecting an `eslint.config.*` file (not introduced by this change).
- Attempted a Playwright page screenshot against `http://127.0.0.1:3000` which failed because the dev server was not running, so no runtime UI screenshot was captured.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b11c0dbfe8832a9858fcad502e800f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated camera permission dialog button text from "Grant Permission" to "Continue" for improved clarity and consistency across the permission request flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->