### PR TITLE
Add 'Block User' option to Vault entry actions

### DIFF
--- a/frontend/app/vault.tsx
+++ b/frontend/app/vault.tsx
@@ -29,18 +29,19 @@ import { useFriends } from '@/hooks/use-friends';
 import { useReportedEntries } from '@/hooks/use-reported-entries';
 import { getDefaultAvatarUrl } from '@/lib/utils';
 import EmptyFriendVault from '@/components/vault/empty-friend-vault';
+import { deviceStorage } from '@/services/device-storage';
 
 const MUSIC_PLAYER_ANIMATION_DURATION = 300;
 const MUSIC_PLAYER_CLEANUP_DELAY = MUSIC_PLAYER_ANIMATION_DURATION + 50;
 
 export default function VaultScreen() {
-  const { profile } = useAuthContext();
+  const { profile, user } = useAuthContext();
   const router = useRouter();
   const params = useLocalSearchParams<{ friendId?: string | string[] }>();
   const selectedFriendId = Array.isArray(params.friendId) ? params.friendId[0] : params.friendId;
   const responsive = useResponsive();
   const { toast } = useToast();
-  const { friends } = useFriends(profile?.id);
+  const { friends, blockFriend: blockFriendAction } = useFriends(profile?.id);
   const { reportedPostIds } = useReportedEntries();
   const {
     entries,
@@ -56,9 +57,12 @@ export default function VaultScreen() {
   } = useUserEntries(selectedFriendId);
   const { selectedEntryId, popupType, isPopupVisible, hidePopup } = usePopupParams();
   const reportedPostIdSet = new Set(reportedPostIds);
+  const [blockedUserIds, setBlockedUserIds] = useState<Set<string>>(new Set());
   const filteredEntriesByDate: Record<string, EntryWithProfile[]> = Object.fromEntries(
     Object.entries(entriesByDate || {}).map(([date, dateEntries]) => {
-      const visibleDateEntries = (dateEntries as EntryWithProfile[]).filter((entry) => !reportedPostIdSet.has(entry.id));
+      const visibleDateEntries = (dateEntries as EntryWithProfile[])
+        .filter((entry) => !reportedPostIdSet.has(entry.id))
+        .filter((entry) => !blockedUserIds.has(entry.user_id));
       return [date, visibleDateEntries];
     }).filter(([, dateEntries]) => dateEntries.length > 0)
   ) as Record<string, EntryWithProfile[]>;
@@ -66,7 +70,6 @@ export default function VaultScreen() {
 
   const [selectedMusic, setSelectedMusic] = useState<MusicTag | null>(null);
   const [isMusicPlayerVisible, setIsMusicPlayerVisible] = useState(false);
-  const [actionEntry, setActionEntry] = useState<EntryWithProfile | null>(null);
   const [isFriendFilterVisible, setIsFriendFilterVisible] = useState(false);
 
   const musicPlayerCleanupTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -200,6 +203,53 @@ export default function VaultScreen() {
     },
   });
 
+
+  const removeUserEntriesFromDevice = useCallback(async (blockedUserId: string) => {
+    if (!user?.id) return;
+
+    const blockedUserEntryIds = entries
+      .filter((vaultEntry) => vaultEntry.user_id === blockedUserId)
+      .map((vaultEntry) => vaultEntry.id);
+
+    if (!blockedUserEntryIds.length) return;
+    await Promise.all(blockedUserEntryIds.map((entryId) => deviceStorage.removeEntry(user.id, entryId)));
+  }, [entries, user?.id]);
+
+  const handleBlockUser = useCallback((entry: EntryWithProfile) => {
+    const friendship = friends.find((friend) => friend.friend_profile.id === entry.user_id);
+    if (!friendship) {
+      toast('Unable to block this user right now.', 'error');
+      return;
+    }
+
+    const friendName = entry.profile?.full_name || entry.profile?.username || 'this user';
+    Alert.alert(
+      'Block User',
+      `Are you sure you want to block ${friendName}? They will no longer be able to interact with you.`,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Block',
+          style: 'destructive',
+          onPress: async () => {
+            const result = await blockFriendAction(friendship.id);
+            if (!result.success) {
+              toast(result.error || 'Failed to block user', 'error');
+              return;
+            }
+
+            setBlockedUserIds((prev) => new Set(prev).add(entry.user_id));
+            await removeUserEntriesFromDevice(entry.user_id);
+            toast('User blocked successfully', 'success');
+            if (selectedFriendId === entry.user_id) {
+              router.setParams({ friendId: undefined });
+            }
+          }
+        }
+      ]
+    );
+  }, [blockFriendAction, friends, removeUserEntriesFromDevice, router, selectedFriendId, toast]);
+
   const handleEntryActions = (entry: EntryWithProfile) => {
     Alert.alert(
       'Entry Actions',
@@ -228,6 +278,11 @@ export default function VaultScreen() {
               ]
             );
           }
+        },
+        {
+          text: 'Block User',
+          style: 'destructive',
+          onPress: () => handleBlockUser(entry),
         },
         {
           text: 'Cancel',

--- a/frontend/app/vault.tsx
+++ b/frontend/app/vault.tsx
@@ -30,6 +30,7 @@ import { useReportedEntries } from '@/hooks/use-reported-entries';
 import { getDefaultAvatarUrl } from '@/lib/utils';
 import EmptyFriendVault from '@/components/vault/empty-friend-vault';
 import { deviceStorage } from '@/services/device-storage';
+import { posthog } from '@/constants/posthog';
 
 const MUSIC_PLAYER_ANIMATION_DURATION = 300;
 const MUSIC_PLAYER_CLEANUP_DELAY = MUSIC_PLAYER_ANIMATION_DURATION + 50;
@@ -212,7 +213,26 @@ export default function VaultScreen() {
       .map((vaultEntry) => vaultEntry.id);
 
     if (!blockedUserEntryIds.length) return;
-    await Promise.all(blockedUserEntryIds.map((entryId) => deviceStorage.removeEntry(user.id, entryId)));
+
+    const removalResults = await Promise.allSettled(
+      blockedUserEntryIds.map((entryId) => deviceStorage.removeEntry(user.id, entryId))
+    );
+    const failedRemovals = removalResults.filter((result) => result.status === 'rejected');
+    if (!failedRemovals.length) return;
+
+    logger.warn('Failed to remove one or more blocked user entries from local storage', {
+      blockedUserEntryCount: blockedUserEntryIds.length,
+      failedRemovalCount: failedRemovals.length,
+    });
+
+    try {
+      posthog.capture('vault_block_storage_cleanup_failed', {
+        blocked_user_entry_count: blockedUserEntryIds.length,
+        failed_removal_count: failedRemovals.length,
+      });
+    } catch (error) {
+      logger.warn('Analytics capture failed for vault storage cleanup error', error);
+    }
   }, [entries, user?.id]);
 
   const handleBlockUser = useCallback((entry: EntryWithProfile) => {


### PR DESCRIPTION
### Motivation
- Provide a way to block the owner of a vault entry directly from the Vault long-press menu so users can take immediate action on problematic entries.
- Reuse the existing blocking flow from the Friends feature to keep behavior consistent across the app.

### Description
- Added a destructive `Block User` option to the Vault entry long-press alert and wired it to a new handler that invokes `useFriends().blockFriend`.
- After a successful block the UI immediately filters out the blocked user's entries by maintaining a `blockedUserIds` set and removing that user's cached entries via `deviceStorage.removeEntry` to mirror the removal performed when reporting an entry.
- Reused the existing friends blocking logic by calling the `blockFriend` action returned from `useFriends(profile?.id)` and surface success/error toasts.
- Removed the unused `actionEntry` state and imported `deviceStorage` to perform local entry removals; the change is contained in `frontend/app/vault.tsx`.

### Testing
- Ran `npm run lint` which failed due to an existing ESLint v9 config mismatch in the repo (missing `eslint.config.*`) and not related to this change.
- Ran `npx tsc --noEmit` which failed due to pre-existing TypeScript errors in unrelated files in the repository, so typecheck failures are not caused by the Vault change.
- No new unit tests were added for this UI change; manual verification is recommended in an environment where the app can run and Supabase/auth are available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b11dfaea50832aa79828007df19424)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added user blocking with a "Block User" action per entry and a confirmation prompt
  * Blocked users' entries are immediately hidden from your vault view
  * Blocking also removes the blocked user's entries from local device storage

* **Bug Fixes**
  * Blocking a currently-viewed user clears that view to prevent stale content
<!-- end of auto-generated comment: release notes by coderabbit.ai -->