### PR TITLE
Track screens with PostHog and enable session replay for native builds

### DIFF
--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -1,4 +1,4 @@
-import { Stack } from 'expo-router';
+import { Stack, useGlobalSearchParams, usePathname } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import * as SplashScreen from 'expo-splash-screen';
 import { useFrameworkReady } from '@/hooks/useFrameworkReady';
@@ -16,11 +16,14 @@ import { initializeBackgroundTasks } from '@/lib/background-task-init';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { useAppFonts } from '@/hooks/useFonts';
 import { Platform } from 'react-native';
+import { posthog } from '@/constants/posthog';
 
 SplashScreen.preventAutoHideAsync();
 
 export default function RootLayout() {
   useFrameworkReady();
+  const pathname = usePathname();
+  const params = useGlobalSearchParams();
 
   // Initialize deep linking
   useDeepLinking();
@@ -38,6 +41,10 @@ export default function RootLayout() {
       SplashScreen.hideAsync();
     }
   }, [fontsLoaded, fontError]);
+
+  useEffect(() => {
+    posthog.screen(pathname, params);
+  }, [params, pathname]);
 
   if (!fontsLoaded && !fontError) {
     return null;

--- a/frontend/constants/posthog.ts
+++ b/frontend/constants/posthog.ts
@@ -34,5 +34,8 @@ const noOpPostHog = {
 const shouldInitializePostHog = apiKey && host && Platform.OS !== 'web';
 
 export const posthog = shouldInitializePostHog
-  ? new PostHog(apiKey, { host })
+  ? new PostHog(apiKey, {
+      host,
+      enableSessionReplay: !__DEV__,
+    })
   : noOpPostHog;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -74,6 +74,7 @@
     "expo-web-browser": "~15.0.10",
     "lucide-react-native": "^0.475.0",
     "posthog-react-native": "^4.17.0",
+    "posthog-react-native-session-replay": "^1.2.0",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-native": "0.81.5",


### PR DESCRIPTION
### Motivation
- Add automatic screen tracking so navigation changes are captured by analytics. 
- Enable PostHog session replay for non-development native runs to aid debugging and session analysis. 

### Description
- Import `posthog` and router helpers `usePathname` and `useGlobalSearchParams` in `frontend/app/_layout.tsx` and call `posthog.screen(pathname, params)` inside a `useEffect` to send screen events. 
- Update `frontend/constants/posthog.ts` to initialize `PostHog` with `enableSessionReplay: !__DEV__` when `apiKey`, `host`, and `Platform.OS !== 'web'` are set, otherwise continue to use the no-op `posthog` mock. 
- Add the `posthog-react-native-session-replay` dependency to `frontend/package.json`. 

### Testing
- Ran TypeScript type-check with `yarn tsc` and the type-check passed. 
- Executed unit tests with `yarn test` and all tests passed. 
- Ran linting with `yarn lint` and there were no lint errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bda6d05c84832a9581b1a8fec021bc)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented screen navigation tracking with analytics integration.
  * Enabled session replay functionality in production environments for enhanced troubleshooting support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->