### PR TITLE
Add PostHog error autocapture to frontend client

### DIFF
--- a/frontend/constants/posthog.ts
+++ b/frontend/constants/posthog.ts
@@ -37,5 +37,12 @@ export const posthog = shouldInitializePostHog
   ? new PostHog(apiKey, {
       host,
       enableSessionReplay: !__DEV__,
+      errorTracking: {
+        autocapture: {
+          uncaughtExceptions: true,
+          unhandledRejections: true,
+          console: ['error', 'warn'],
+        },
+      },
     })
   : noOpPostHog;


### PR DESCRIPTION
### Motivation
- Automatically capture frontend errors so uncaught exceptions, unhandled promise rejections, and console `error`/`warn` messages are reported to PostHog for observability and faster incident detection.

### Description
- Added `errorTracking.autocapture` to the PostHog initialization in `frontend/constants/posthog.ts` enabling `uncaughtExceptions: true`, `unhandledRejections: true`, and `console: ['error', 'warn']` while preserving existing `host`, `enableSessionReplay`, and web/no-op initialization behavior.

### Testing
- Ran `git diff --check` which reported no issues and confirmed the intended diff.
- Ran `npx tsc --noEmit` which failed due to pre-existing TypeScript errors elsewhere in the frontend unrelated to this configuration change.
- Ran `npm run lint` which failed in this environment because the project uses a legacy ESLint setup and the runner expects a flat `eslint.config.js`, unrelated to the small PostHog change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bdb64026ac832aa4fba45c2cca4103)